### PR TITLE
Fix 3 dc:contributor tags and a definition

### DIFF
--- a/src/ontology/ohd-edit.owl
+++ b/src/ontology/ohd-edit.owl
@@ -1440,7 +1440,7 @@ AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000091 "PERSON: Bill Duncan")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000091 "Adapted from:
 Mosby's Dental Dictionary, 2nd Edition. page 580. 
 Wikipedia: http://en.wikipedia.org/wiki/Dental_restoration")
-AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000091 "PERSON: Bill Duncan")
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000091 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000091 "is dental restoration of")
 ObjectPropertyRange(obo:OHD_0000091 ObjectSomeValuesFrom(obo:BFO_0000050 obo:FMA_12516))
 
@@ -3002,7 +3002,7 @@ SubClassOf(obo:OHD_0000090 ObjectHasValue(obo:BFO_0000051 obo:OHD_0000132))
 
 AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000093 "A dental finding that a tooth was present during a clinical exam.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000093 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000093 "Alan Ruttenberg")
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000093 <https://orcid.org/0000-0002-1604-3078>)
 AnnotationAssertion(rdfs:label obo:OHD_0000093 "tooth clinically present finding")
 SubClassOf(obo:OHD_0000093 obo:OHD_0000010)
 SubClassOf(obo:OHD_0000093 ObjectSomeValuesFrom(obo:IAO_0000136 obo:FMA_12516))
@@ -3282,8 +3282,8 @@ EquivalentClasses(obo:OHD_0000167 ObjectIntersectionOf(obo:OHD_0000022 ObjectSom
 # Class: obo:OHD_0000168 (unerupted tooth finding)
 
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000168 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000168 "A dental finding that a tooth has not errupted.")
-AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000168 "Alan Ruttenberg")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000168 "A dental finding that a tooth has not errupted.")
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:OHD_0000168 <https://orcid.org/0000-0002-1604-3078>)
 AnnotationAssertion(rdfs:label obo:OHD_0000168 "unerupted tooth finding")
 SubClassOf(obo:OHD_0000168 obo:OHD_0000010)
 


### PR DESCRIPTION
Fixes the use for "string" values in use with dcterms:contributor Fixes one wrong use of a definition tag