### PR TITLE
add axiom 'located in some Mouth'

### DIFF
--- a/src/ontology/ohd-edit.owl
+++ b/src/ontology/ohd-edit.owl
@@ -6262,6 +6262,10 @@ AnnotationAssertion(dcterms:created obo:OHD_0008052 "2025-04-04T13:31:33Z"^^xsd:
 AnnotationAssertion(rdfs:label obo:OHD_0008052 "increased heart rate"@en)
 SubClassOf(obo:OHD_0008052 obo:OGMS_0000060)
 
+# Class: obo:OHMI_0000015 (microbiome in human oral)
+
+SubClassOf(obo:OHMI_0000015 ObjectSomeValuesFrom(obo:RO_0001025 obo:FMA_49184))
+
 # Class: obo:OMRSE_00000007 (gender role)
 
 SubClassOf(obo:OMRSE_00000007 obo:BFO_0000023)


### PR DESCRIPTION
This axiom to is to infer that [OHMI:microbiome in human oral](http://purl.obolibrary.org/obo/OHMI_0000015) is also a subclass of [OHD:oral microbiome](http://purl.obolibrary.org/obo/OHD_0000418). The OHMI term doesn't account for oral microbiomes in other species.  
(see OHMI issue https://github.com/ohmi-ontology/ohmi/issues/12) 