### PR TITLE
Obo dashboard fixes

### DIFF
--- a/src/ontology/components/dental_material.owl
+++ b/src/ontology/components/dental_material.owl
@@ -337,10 +337,10 @@ SubClassOf(obo:CHEBI_52257 ObjectSomeValuesFrom(obo:BFO_0000051 obo:CHEBI_52257)
 
 # Class: obo:OHD_0000000 (dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000000 "A processed material that bears a dental restoration material role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000000 "A processed material that bears a dental restoration material role."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000000 "restoration material")
 AnnotationAssertion(terms:contributor obo:OHD_0000000 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000000 "dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000000 "dental restoration material"@en)
 EquivalentClasses(obo:OHD_0000000 ObjectIntersectionOf(obo:OBI_0000047 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000191)))
 SubClassOf(obo:OHD_0000000 ObjectSomeValuesFrom(obo:BFO_0000053 obo:OHD_0000191))
 
@@ -352,18 +352,18 @@ AnnotationAssertion(terms:contributor obo:OHD_0000001 <https://orcid.org/0000-00
 AnnotationAssertion(terms:contributor obo:OHD_0000001 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0000001 <https://orcid.org/0000-0003-1829-971X>)
 AnnotationAssertion(rdfs:comment obo:OHD_0000001 "Color depends on which metal is in the alloy at what % (e.g. if copper is more, amalgam become blackish).")
-AnnotationAssertion(rdfs:label obo:OHD_0000001 "amalgam dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000001 "amalgam dental restoration material"@en)
 SubClassOf(obo:OHD_0000001 obo:OHD_0000048)
 
 # Class: obo:OHD_0000034 (gold foil dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000034 "A metal dental restoration material in which the principal ingredient is gold.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000034 "A metal dental restoration material in which the principal ingredient is gold."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000034 "Bill Duncan 12/11/2014:
 updated defintion")
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000034 "Titus Schleyer 3/13/2014: slightly updated definition")
 AnnotationAssertion(terms:contributor obo:OHD_0000034 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0000034 <https://orcid.org/0000-0003-1829-971X>)
-AnnotationAssertion(rdfs:label obo:OHD_0000034 "gold foil dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000034 "gold foil dental restoration material"@en)
 SubClassOf(obo:OHD_0000034 obo:OHD_0000048)
 
 # Class: obo:OHD_0000036 (resin-based composite dental restoration material)
@@ -374,7 +374,7 @@ AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000036 "Titus Schleyer 3/13/2014: u
 Bill D. 08-04-2023: Not all resins are tooth colored. Some are cream colored. Also, updated definition source Craig's restorative Dental Material.")
 AnnotationAssertion(terms:contributor obo:OHD_0000036 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0000036 <https://orcid.org/0000-0003-1829-971X>)
-AnnotationAssertion(rdfs:label obo:OHD_0000036 "resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000036 "resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0000036 obo:OHD_0000000)
 
 # Class: obo:OHD_0000048 (metal dental restoration material)
@@ -382,7 +382,7 @@ SubClassOf(obo:OHD_0000036 obo:OHD_0000000)
 AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000048 "A dental restoration material that consists mostly of metal and metal alloys."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000048 "Use CHEBI:33521 'metal ion' in a complete definition. Figure out how to say \"mostly\" first, however."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0000048 <https://orcid.org/0000-0001-6424-4096>)
-AnnotationAssertion(rdfs:label obo:OHD_0000048 "metal dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000048 "metal dental restoration material"@en)
 SubClassOf(obo:OHD_0000048 obo:OHD_0000000)
 
 # Class: obo:OHD_00001025 (mineral trioxide aggregate cement dental restoration material)
@@ -392,28 +392,28 @@ Restorative dentistry & endodontics, 37(4), pp.188-193.") obo:IAO_0000115 obo:OH
 AnnotationAssertion(terms:contributor obo:OHD_00001025 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_00001025 "2023-10-12T21:52:17Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:comment obo:OHD_00001025 "It is used in pulp capping, apexification, pulpotomy, and treatment of perforation.")
-AnnotationAssertion(rdfs:label obo:OHD_00001025 "mineral trioxide aggregate cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_00001025 "mineral trioxide aggregate cement dental restoration material"@en)
 SubClassOf(obo:OHD_00001025 obo:OHD_0000000)
 
 # Class: obo:OHD_0000135 (ceramic dental restoration material)
 
 AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN: 9780323697552") obo:IAO_0000115 obo:OHD_0000135 "A dental restoration material that has a nonmetallic inorganic structure consisting primarily of compounds containing oxygen combined with one or more metallic or semi-metallic elements that are processed at high temperatures, pressed, and polished or milled.")
 AnnotationAssertion(terms:contributor obo:OHD_0000135 <https://orcid.org/0000-0001-6424-4096>)
-AnnotationAssertion(rdfs:label obo:OHD_0000135 "ceramic dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000135 "ceramic dental restoration material"@en)
 SubClassOf(obo:OHD_0000135 obo:OHD_0000000)
 
 # Class: obo:OHD_0000136 (titanium dental restoration material)
 
 AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000136 "A metal dental restoration material that contains 85% or more titanium.")
 AnnotationAssertion(terms:contributor obo:OHD_0000136 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000136 "titanium dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000136 "titanium dental restoration material"@en)
 SubClassOf(obo:OHD_0000136 obo:OHD_0000048)
 
 # Class: obo:OHD_0000137 (stainless steel dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000137 "A metal dental restoration material in which the principal ingredient is stainless steel.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000137 "A metal dental restoration material in which the principal ingredient is stainless steel."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0000137 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000137 "stainless steel dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000137 "stainless steel dental restoration material"@en)
 SubClassOf(obo:OHD_0000137 obo:OHD_0000048)
 
 # Class: obo:OHD_0000146 (noble metal dental restoration material)
@@ -421,7 +421,7 @@ SubClassOf(obo:OHD_0000137 obo:OHD_0000048)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000146 "A metal dental restoration material that is composed of a metallic alloy that contains 25% or more (by weight) of noble metal elements.")
 AnnotationAssertion(terms:contributor obo:OHD_0000146 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:comment obo:OHD_0000146 "Noble metal elements include Gold, Palladium, Platinum, Rhodium, Ruthenium, Iridium, and Osmium.")
-AnnotationAssertion(rdfs:label obo:OHD_0000146 "noble metal dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000146 "noble metal dental restoration material"@en)
 SubClassOf(obo:OHD_0000146 obo:OHD_0000048)
 
 # Class: obo:OHD_0000147 (high noble metal dental restoration material)
@@ -430,7 +430,7 @@ AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Cu
 AnnotationAssertion(terms:contributor obo:OHD_0000147 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:contributor obo:OHD_0000147 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0000147 <https://orcid.org/0009-0002-7282-0836>)
-AnnotationAssertion(rdfs:label obo:OHD_0000147 "high noble metal dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000147 "high noble metal dental restoration material"@en)
 SubClassOf(obo:OHD_0000147 obo:OHD_0000146)
 
 # Class: obo:OHD_0000156 (predominantly base metal dental restoration material)
@@ -438,7 +438,7 @@ SubClassOf(obo:OHD_0000147 obo:OHD_0000146)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000156 "A metal dental restoration material that is composed of group of cast metals that rely on Chromium for corrosion resistance.")
 AnnotationAssertion(terms:contributor obo:OHD_0000156 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:contributor obo:OHD_0000156 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000156 "predominantly base metal dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000156 "predominantly base metal dental restoration material"@en)
 SubClassOf(obo:OHD_0000156 obo:OHD_0000048)
 
 # Class: obo:OHD_0000191 (dental restoration material role)
@@ -453,7 +453,7 @@ Widened the definition to include other materials used in restoration processes 
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000191 "Titus Schleyer 1/1/2014: updated definition")
 AnnotationAssertion(terms:contributor obo:OHD_0000191 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0000191 <https://orcid.org/0000-0003-1829-971X>)
-AnnotationAssertion(rdfs:label obo:OHD_0000191 "dental restoration material role")
+AnnotationAssertion(rdfs:label obo:OHD_0000191 "dental restoration material role"@en)
 
 # Class: obo:OHD_0001005 (resin-based cement dental restoration material)
 
@@ -461,36 +461,36 @@ AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:0323478212") Annotation(obo
 AnnotationAssertion(terms:contributor obo:OHD_0001005 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001005 "2023-08-07T15:16:39Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:comment obo:OHD_0001005 "It is intended for use in the cementation or fixation of restorations and appliances.")
-AnnotationAssertion(rdfs:label obo:OHD_0001005 "resin-based cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001005 "resin-based cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001005 obo:OHD_0000000)
 
 # Class: obo:OHD_0001006 (glass ionomer cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001006 "An acid-base cement dental restoration material containing basic ion-leachable glass (fluoroaluminosilicate glass) as a powder component with polymeric water-soluble acid (polyacrylic acid, polyprotic carboxylic acid) as liquid component to complete the acid-base reaction.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001006 "An acid-base cement dental restoration material containing basic ion-leachable glass (fluoroaluminosilicate glass) as a powder component with polymeric water-soluble acid (polyacrylic acid, polyprotic carboxylic acid) as liquid component to complete the acid-base reaction."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001006 "Glass Ionomer Cement (GIC)"@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001006 "glass polyalkenoate cement"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001006 "doi:10.3390/jfb7030016")
 AnnotationAssertion(terms:contributor obo:OHD_0001006 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001006 "2023-07-19T15:23:33Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001006 "glass ionomer cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001006 "glass ionomer cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001006 obo:OHD_0001021)
 
 # Class: obo:OHD_0001007 (zinc oxide eugenol cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001007 "A zinc-oxide cement dental restoration material containing eugenol as a liquid component to complete the acid-base reaction.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001007 "A zinc-oxide cement dental restoration material containing eugenol as a liquid component to complete the acid-base reaction."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001007 "ISBN:0323478212")
 AnnotationAssertion(terms:contributor obo:OHD_0001007 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001007 "2023-07-21T13:58:36Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001007 "zinc oxide eugenol cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001007 "zinc oxide eugenol cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001007 obo:OHD_0001022)
 SubClassOf(obo:OHD_0001007 ObjectSomeValuesFrom(obo:BFO_0000051 obo:CHEBI_4917))
 
 # Class: obo:OHD_0001008 (calcium aluminate glass ionomer hybrid cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001008 "A dental restoration material containing calcium aluminate, polyacrylic acid  with basic ion-leachable glass particles as powder component with water as liquid component to complete the acid-base reaction of glass ionomer and hydration of calcium aluminate cement.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001008 "A dental restoration material containing calcium aluminate, polyacrylic acid  with basic ion-leachable glass particles as powder component with water as liquid component to complete the acid-base reaction of glass ionomer and hydration of calcium aluminate cement."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001008 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001008 "2024-02-08T11:22:23Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001008 "calcium aluminate glass ionomer hybrid cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001008 "calcium aluminate glass ionomer hybrid cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001008 obo:OHD_0000000)
 
 # Class: obo:OHD_0001010 (zinc oxide non-eugenol cement dental restoration material)
@@ -498,7 +498,7 @@ SubClassOf(obo:OHD_0001008 obo:OHD_0000000)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:0323478212") Annotation(obo:IAO_0000119 "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9689175/") obo:IAO_0000115 obo:OHD_0001010 "A zinc-oxide cement dental restoration material containing aliphatic acid or butyric acid to substitute the eugenol as a liquid component to complete the acid-base reaction.")
 AnnotationAssertion(terms:contributor obo:OHD_0001010 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001010 "2023-07-31T12:05:19Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001010 "zinc oxide non-eugenol cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001010 "zinc oxide non-eugenol cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001010 obo:OHD_0001022)
 
 # Class: obo:OHD_0001011 (bulk-filled resin-based composite dental restoration material)
@@ -506,7 +506,7 @@ SubClassOf(obo:OHD_0001010 obo:OHD_0001022)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001011 "A resin-based composite dental restoration material that enables the restoration to be built up in thick layers of up to 4 mm and are recommended by manufacturers to simplify clinical technique and save time compared to traditional incremental placement.")
 AnnotationAssertion(terms:contributor obo:OHD_0001011 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001011 "2023-07-31T12:07:09Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001011 "bulk-filled resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001011 "bulk-filled resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0001011 obo:OHD_0000036)
 
 # Class: obo:OHD_0001012 (flowable resin-based composite dental restoration material)
@@ -514,7 +514,7 @@ SubClassOf(obo:OHD_0001011 obo:OHD_0000036)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001012 "A resin-based composite dental restoration material that has low-viscosity and is recommended for cervical lesions, restorations in deciduous teeth, and other small, low- or non-stress bearing restorations.")
 AnnotationAssertion(terms:contributor obo:OHD_0001012 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001012 "2023-07-31T12:07:24Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001012 "flowable resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001012 "flowable resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0001012 obo:OHD_0000036)
 
 # Class: obo:OHD_0001014 (macrofilled resin-based composite dental restoration material)
@@ -522,7 +522,7 @@ SubClassOf(obo:OHD_0001012 obo:OHD_0000036)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001014 "A resin-based composite dental restoration material that contains macrosize filler particles.")
 AnnotationAssertion(terms:contributor obo:OHD_0001014 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001014 "2023-07-31T12:08:04Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001014 "macrofilled resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001014 "macrofilled resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0001014 obo:OHD_0000036)
 
 # Class: obo:OHD_0001015 (microfilled resin-based composite dental restoration material)
@@ -530,7 +530,7 @@ SubClassOf(obo:OHD_0001014 obo:OHD_0000036)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001015 "A resin-based composite dental restoration material which is composed of dimethacrylate resins with 0.04-m colloidal silica fillers and prepolymerized resins, which are sometimes filled with colloidal silica.")
 AnnotationAssertion(terms:contributor obo:OHD_0001015 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001015 "2023-07-31T12:08:13Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001015 "microfilled resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001015 "microfilled resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0001015 obo:OHD_0000036)
 
 # Class: obo:OHD_0001017 (nano filled resin-based composite dental restoration material)
@@ -538,7 +538,7 @@ SubClassOf(obo:OHD_0001015 obo:OHD_0000036)
 AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001017 "A resin-based composite dental restoration material that contains nanometer-sized filler particles (1 to 100 nm) throughout the resin matrix.")
 AnnotationAssertion(terms:contributor obo:OHD_0001017 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001017 "2023-07-31T12:08:41Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001017 "nano filled resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001017 "nano filled resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0001017 obo:OHD_0000036)
 
 # Class: obo:OHD_0001018 (nano hybrid resin-based composite dental restoration material)
@@ -548,7 +548,7 @@ AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Mater
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001018 "Craig's restorative Dental Material"@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001018 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001018 "2023-07-31T12:08:57Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001018 "nano hybrid resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001018 "nano hybrid resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0001018 obo:OHD_0000036)
 
 # Class: obo:OHD_0001019 (compomer resin-based composite dental restoration material)
@@ -558,46 +558,46 @@ AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001019 "polyacid-modified glass ion
 AnnotationAssertion(terms:contributor obo:OHD_0001019 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001019 "2023-07-31T12:09:12Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:OHD_0001019 "ISBN:978-81-312-3488-4")
-AnnotationAssertion(rdfs:label obo:OHD_0001019 "compomer resin-based composite dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001019 "compomer resin-based composite dental restoration material"@en)
 SubClassOf(obo:OHD_0001019 obo:OHD_0000036)
 
 # Class: obo:OHD_0001020 (metal modified glass ionomer dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001020 "An acid-base cement dental restoration material where in  glass ionomer cements  the glasses are fused with metals such as gold, silver, titanium, and silver to improve their strength.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001020 "An acid-base cement dental restoration material where in  glass ionomer cements  the glasses are fused with metals such as gold, silver, titanium, and silver to improve their strength."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001020 "cermet dental restoration material"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001020 "ISBN:0323478212"@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001020 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001020 "2023-07-31T15:40:29Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001020 "metal modified glass ionomer dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001020 "metal modified glass ionomer dental restoration material"@en)
 SubClassOf(obo:OHD_0001020 obo:OHD_0001021)
 
 # Class: obo:OHD_0001021 (acid-base cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001021 "A dental restoration material containing acid and liquid components in powder liquid form.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001021 "A dental restoration material containing acid and liquid components in powder liquid form."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001021 "ISBN:0323478212")
 AnnotationAssertion(terms:contributor obo:OHD_0001021 <https://orcid.org/0000-0001-6424-4096>)
-AnnotationAssertion(rdfs:label obo:OHD_0001021 "acid-base cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001021 "acid-base cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001021 obo:OHD_0000000)
 
 # Class: obo:OHD_0001022 (zinc oxide cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001022 "An acid-base cement dental restoration material containing zinc-oxide as a powder component with some specific liquid component to complete the acid-base reaction.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001022 "An acid-base cement dental restoration material containing zinc-oxide as a powder component with some specific liquid component to complete the acid-base reaction."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001022 "ISBN:0323478212")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001022 "https://www.iso.org/standard/84407.html")
 AnnotationAssertion(terms:contributor obo:OHD_0001022 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001022 "2023-08-05T15:44:55Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001022 "zinc oxide cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001022 "zinc oxide cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001022 obo:OHD_0001021)
 SubClassOf(obo:OHD_0001022 ObjectSomeValuesFrom(obo:BFO_0000051 obo:CHEBI_36560))
 
 # Class: obo:OHD_0001026 (resin-modified glass ionomer dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001026 "An acid-base cement dental restoration material with modification of  glass ionomer cement with some monomer component and associated activator initiator system to facilitate light and chemically activated polymerization reaction.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001026 "An acid-base cement dental restoration material with modification of  glass ionomer cement with some monomer component and associated activator initiator system to facilitate light and chemically activated polymerization reaction."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001026 "doi: 10.3390/jfb7030016")
 AnnotationAssertion(terms:contributor obo:OHD_0001026 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001026 "2023-08-08T12:27:23Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:comment obo:OHD_0001026 "The monomer is typically 2-hydroxyethyl methacrylate, HEMA, and the initiator is camphorquinone. Resin-modified glass-ionomers set by the twin processes of neutralization (acid-base reaction) and addition polymerization, and the resulting material has a complicated structure based on the combined products of these two reactions.")
-AnnotationAssertion(rdfs:label obo:OHD_0001026 "resin-modified glass ionomer dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001026 "resin-modified glass ionomer dental restoration material"@en)
 SubClassOf(obo:OHD_0001026 obo:OHD_0001021)
 
 # Class: obo:OHD_0001032 (glass matrix ceramic dental restoration material)
@@ -610,7 +610,7 @@ SubClassOf(obo:OHD_0001032 obo:OHD_0000135)
 
 # Class: obo:OHD_0001033 (polycrystalline ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001033 "A ceramic dental restoration material that contains small crystals, also known as grains, that are separated by grain boundaries and present a random crystallographic orientation , that do not contain a glass phase.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001033 "A ceramic dental restoration material that contains small crystals, also known as grains, that are separated by grain boundaries and present a random crystallographic orientation , that do not contain a glass phase."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001033 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001033 "2024-08-30T13:41:52Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001033 "polycrystalline ceramic dental restoration material"@en)
@@ -629,7 +629,7 @@ SubClassOf(obo:OHD_0001034 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0001080)
 
 # Class: obo:OHD_0001035 (3Y-TZP zirconia ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001035 "A zirconia polycrystalline ceramic dental restoration material that contains the first generation of dental zirconia fully stabilized with yttria (Y2O3) which are chiefly composed of the tetragonal phase (tetragonal zirconia polycrystals : TZPs) and are stabilized at room temperature with the addition of 3 mol% of yttrium oxide (3Y-TZP).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001035 "A zirconia polycrystalline ceramic dental restoration material that contains the first generation of dental zirconia fully stabilized with yttria (Y2O3) which are chiefly composed of the tetragonal phase (tetragonal zirconia polycrystals : TZPs) and are stabilized at room temperature with the addition of 3 mol% of yttrium oxide (3Y-TZP)."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001035 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001035 "2024-08-30T13:43:04Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001035 "3Y-TZP zirconia ceramic dental restoration material"@en)
@@ -637,7 +637,7 @@ SubClassOf(obo:OHD_0001035 obo:OHD_0001034)
 
 # Class: obo:OHD_0001036 (4Y-PSZ zirconia ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001036 "A zirconia polycrystalline ceramic dental restoration material that contains the next generation of dental zirconia with the addition of transparent, non-birefringent, cubic-phase stabilized with higher yttrium oxide (of approximately 25% of the cubic phase achieved with 4 mol% of yttrium oxide) with increased translucency in relation to 3Y-TZP for monolithic applications.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001036 "A zirconia polycrystalline ceramic dental restoration material that contains the next generation of dental zirconia with the addition of transparent, non-birefringent, cubic-phase stabilized with higher yttrium oxide (of approximately 25% of the cubic phase achieved with 4 mol% of yttrium oxide) with increased translucency in relation to 3Y-TZP for monolithic applications."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001036 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001036 "2024-08-30T13:43:16Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001036 "4Y-PSZ zirconia ceramic dental restoration material"@en)
@@ -645,7 +645,7 @@ SubClassOf(obo:OHD_0001036 obo:OHD_0001034)
 
 # Class: obo:OHD_0001037 (5Y-PSZ zirconia ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001037 "A zirconia polycrystalline ceramic dental restoration material that contains zirconia with increased yttrium oxide (5-8% mol)")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001037 "A zirconia polycrystalline ceramic dental restoration material that contains zirconia with increased yttrium oxide (5-8% mol)"@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001037 "ultra translucent zironia")
 AnnotationAssertion(terms:contributor obo:OHD_0001037 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001037 "2024-08-30T13:43:35Z"^^xsd:dateTime)
@@ -654,7 +654,7 @@ SubClassOf(obo:OHD_0001037 obo:OHD_0001034)
 
 # Class: obo:OHD_0001038 (multichromatic zirconia ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001038 "A zirconia polycrystalline ceramic dental restoration material that contains additions of layers of different pigments to provide a graded shade between the cervical and the incisal portion of the restoration to mimic the natural tooth appearance.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001038 "A zirconia polycrystalline ceramic dental restoration material that contains additions of layers of different pigments to provide a graded shade between the cervical and the incisal portion of the restoration to mimic the natural tooth appearance."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001038 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001038 "2024-08-30T13:43:50Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001038 "multichromatic zirconia ceramic dental restoration material"@en)
@@ -662,7 +662,7 @@ SubClassOf(obo:OHD_0001038 obo:OHD_0001034)
 
 # Class: obo:OHD_0001039 (multilayered zirconia ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001039 "A zirconia polycrystalline ceramic dental restoration material that contains layered structure composed of different compositions of dental zirconias to provide graded structures that mimic not only the shade, but the translucency and esthetic appearance of natural teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001039 "A zirconia polycrystalline ceramic dental restoration material that contains layered structure composed of different compositions of dental zirconias to provide graded structures that mimic not only the shade, but the translucency and esthetic appearance of natural teeth."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001039 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001039 "2024-08-30T13:44:12Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001039 "multilayered zirconia ceramic dental restoration material"@en)
@@ -678,7 +678,7 @@ SubClassOf(obo:OHD_0001040 obo:OHD_0001033)
 
 # Class: obo:OHD_0001041 (zirconia toughened alumina ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001041 "A polycrystalline composite ceramic dental restoration material that combines zirconium to increase the material's mechanical and esthetic properties.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001041 "A polycrystalline composite ceramic dental restoration material that combines zirconium to increase the material's mechanical and esthetic properties."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001041 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001041 "2024-08-30T13:44:55Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001041 "zirconia toughened alumina ceramic dental restoration material"@en)
@@ -687,42 +687,42 @@ SubClassOf(obo:OHD_0001041 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0001079)
 
 # Class: obo:OHD_0001042 (zinc phosphate cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001042 "An acid-base cement dental restoration material containing zinc-oxide and magnesium oxide as a powder component with phosphoric acid as liquid component to complete the acid-base reaction.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001042 "An acid-base cement dental restoration material containing zinc-oxide and magnesium oxide as a powder component with phosphoric acid as liquid component to complete the acid-base reaction."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001042 "ISBN:0323478212")
 AnnotationAssertion(terms:contributor obo:OHD_0001042 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001042 "2023-09-14T16:34:50Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001042 "zinc phosphate cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001042 "zinc phosphate cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001042 obo:OHD_0001021)
 
 # Class: obo:OHD_0001043 (zinc polycarboxylate cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001043 "An acid-base cement dental restoration material containing zinc-oxide and magnesium oxide as a powder component with polyacrylic acid and water as liquid component to complete the acid-base reaction.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001043 "An acid-base cement dental restoration material containing zinc-oxide and magnesium oxide as a powder component with polyacrylic acid and water as liquid component to complete the acid-base reaction."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001043 "ISBN:0323478212")
 AnnotationAssertion(terms:contributor obo:OHD_0001043 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001043 "2023-09-14T16:35:15Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001043 "zinc polycarboxylate cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001043 "zinc polycarboxylate cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001043 obo:OHD_0001021)
 
 # Class: obo:OHD_0001044 (dental prosthesis support role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001044 "A dental restoration material role that is borne by a portion of dental restoration material in association with bulk restoration and is realized in a tooth restoration procedure in which the restoration material becomes part of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001044 "A dental restoration material role that is borne by a portion of dental restoration material in association with bulk restoration and is realized in a tooth restoration procedure in which the restoration material becomes part of a restored tooth."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001044 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001044 "2023-10-12T11:44:24Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001044 "dental prosthesis support role")
+AnnotationAssertion(rdfs:label obo:OHD_0001044 "dental prosthesis support role"@en)
 SubClassOf(obo:OHD_0001044 obo:OHD_0000191)
 
 # Class: obo:OHD_0001045 (calcium hydroxide cement dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001045 "A dental restoration material that contains calcium hydroxide as a chief ingredient and is suspended in a solvent carrier with a thickening agent.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001045 "A dental restoration material that contains calcium hydroxide as a chief ingredient and is suspended in a solvent carrier with a thickening agent."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001045 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001045 "2023-10-12T12:11:12Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0001045 "calcium hydroxide cement dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0001045 "calcium hydroxide cement dental restoration material"@en)
 SubClassOf(obo:OHD_0001045 obo:OHD_0000000)
 SubClassOf(obo:OHD_0001045 ObjectSomeValuesFrom(obo:BFO_0000051 obo:CHEBI_31341))
 
 # Class: obo:OHD_0001046 (alumina toughened zirconia ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001046 "A polycrystalline composite ceramic dental restoration material that combine alumina to increase materials strength and toughness.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001046 "A polycrystalline composite ceramic dental restoration material that combine alumina to increase materials strength and toughness."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001046 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001046 "2024-08-30T13:45:12Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001046 "alumina toughened zirconia ceramic dental restoration material"@en)
@@ -731,7 +731,7 @@ SubClassOf(obo:OHD_0001046 ObjectSomeValuesFrom(obo:BFO_0000051 obo:CHEBI_30187)
 
 # Class: obo:OHD_0001047 (resin matrix ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001047 "A ceramic dental restoration material that consists of a ceramic network infiltrated with a polymer resin to integrate the mechanical properties of ceramics with the improved elasticity of resins.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001047 "A ceramic dental restoration material that consists of a ceramic network infiltrated with a polymer resin to integrate the mechanical properties of ceramics with the improved elasticity of resins."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001047 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001047 "2024-08-30T13:45:40Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001047 "resin matrix ceramic dental restoration material"@en)
@@ -739,7 +739,7 @@ SubClassOf(obo:OHD_0001047 obo:OHD_0000135)
 
 # Class: obo:OHD_0001048 (resin nano ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001048 "A resin matrix ceramic dental restoration material that contains nano ceramic filler, typically to improve esthetics, strength, and wear resistance.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001048 "A resin matrix ceramic dental restoration material that contains nano ceramic filler, typically to improve esthetics, strength, and wear resistance."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001048 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001048 "2024-08-30T13:46:29Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001048 "resin nano ceramic dental restoration material"@en)
@@ -747,7 +747,7 @@ SubClassOf(obo:OHD_0001048 obo:OHD_0001047)
 
 # Class: obo:OHD_0001049 (resin matrix glass ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001049 "A resin matrix ceramic dental restoration material that contains either lithium disilicate or leucite-reinforced glass ceramic filler, typically to improve esthetics, strength, and wear resistance.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001049 "A resin matrix ceramic dental restoration material that contains either lithium disilicate or leucite-reinforced glass ceramic filler, typically to improve esthetics, strength, and wear resistance."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001049 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001049 "2024-08-30T13:46:51Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001049 "resin matrix glass ceramic dental restoration material"@en)
@@ -755,7 +755,7 @@ SubClassOf(obo:OHD_0001049 obo:OHD_0001047)
 
 # Class: obo:OHD_0001050 (resin matrix zirconia silica ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001050 "A resin matrix ceramic dental restoration material that contains zirconia or silica based ceramic filler, typically to improve esthetics, strength, and wear resistance.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001050 "A resin matrix ceramic dental restoration material that contains zirconia or silica based ceramic filler, typically to improve esthetics, strength, and wear resistance."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001050 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001050 "2024-08-30T13:47:07Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001050 "resin matrix zirconia silica ceramic dental restoration material"@en)
@@ -763,7 +763,7 @@ SubClassOf(obo:OHD_0001050 obo:OHD_0001047)
 
 # Class: obo:OHD_0001051 (feldspathic glass matrix ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001051 "A glass matrix ceramic dental restoration material that primarily contains a ternary material system composed of kaolin (hydrated aluminosilicate), silica, and naturally occurring feldspar (a mixture of potassium and sodium aluminosilicates).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001051 "A glass matrix ceramic dental restoration material that primarily contains a ternary material system composed of kaolin (hydrated aluminosilicate), silica, and naturally occurring feldspar (a mixture of potassium and sodium aluminosilicates)."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001051 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001051 "2024-08-30T13:47:42Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001051 "feldspathic glass matrix ceramic dental restoration material"@en)
@@ -774,7 +774,7 @@ SubClassOf(obo:OHD_0001051 ObjectSomeValuesFrom(obo:BFO_0000051 obo:ENVO_0100048
 
 # Class: obo:OHD_0001052 (synthetic glass matrix ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001052 "A glass matrix ceramic dental restoration material that contains synthetic materials which varies among manufacturers, but commonly includes silicon dioxide (SiO2), potassium oxide (K2O), sodium oxide (Na2O), and aluminum oxide (Al2O3).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001052 "A glass matrix ceramic dental restoration material that contains synthetic materials which varies among manufacturers, but commonly includes silicon dioxide (SiO2), potassium oxide (K2O), sodium oxide (Na2O), and aluminum oxide (Al2O3)."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001052 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001052 "2024-08-30T13:47:59Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001052 "synthetic glass matrix ceramic dental restoration material"@en)
@@ -785,7 +785,7 @@ SubClassOf(obo:OHD_0001052 ObjectSomeValuesFrom(obo:BFO_0000051 obo:CHEBI_88321)
 
 # Class: obo:OHD_0001053 (leucite based synthetic glass matrix ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001053 "A synthetic glass matrix ceramic that contains a leucite (K2OAl2O34SiO2) crystalline phase dispersed in a glass matrix.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001053 "A synthetic glass matrix ceramic that contains a leucite (K2OAl2O34SiO2) crystalline phase dispersed in a glass matrix."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001053 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001053 "2024-08-30T13:48:16Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001053 "leucite based synthetic glass matrix ceramic dental restoration material"@en)
@@ -793,7 +793,7 @@ SubClassOf(obo:OHD_0001053 obo:OHD_0001052)
 
 # Class: obo:OHD_0001054 (lithia based synthetic glass matrix ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001054 "A synthetic glass matrix ceramic that contains a lithium disilicate system (SiO2-Li2O-K2O-ZnO-P2O5 Al2O3-[zirconium dioxide] ZrO2).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001054 "A synthetic glass matrix ceramic that contains a lithium disilicate system (SiO2-Li2O-K2O-ZnO-P2O5 Al2O3-[zirconium dioxide] ZrO2)."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001054 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001054 "2024-08-30T13:48:33Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001054 "lithia based synthetic glass matrix ceramic dental restoration material"@en)
@@ -802,7 +802,7 @@ SubClassOf(obo:OHD_0001054 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0001081)
 
 # Class: obo:OHD_0001055 (fluorapatite based synthetic glass matrix ceramic dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001055 "A synthetic glass matrix ceramic in which the glass phases may be combined with apatite crystals, in addition to leucite, for thermal expansion compatibility with metals and for improved strength.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001055 "A synthetic glass matrix ceramic in which the glass phases may be combined with apatite crystals, in addition to leucite, for thermal expansion compatibility with metals and for improved strength."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001055 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001055 "2024-08-30T13:48:47Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001055 "fluorapatite based synthetic glass matrix ceramic dental restoration material"@en)
@@ -810,7 +810,7 @@ SubClassOf(obo:OHD_0001055 obo:OHD_0001052)
 
 # Class: obo:OHD_0001076 (sodium oxide)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001076 "A  metal oxide which contain sodium and oxygen.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001076 "A  metal oxide which contain sodium and oxygen."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001076 "Compound CID: 73971 
 https://pubchem.ncbi.nlm.nih.gov/compound/73971")
 AnnotationAssertion(obo:OHD_0008045 obo:OHD_0001076 "disodium;oxygen(2-)")
@@ -821,7 +821,7 @@ SubClassOf(obo:OHD_0001076 obo:CHEBI_133331)
 
 # Class: obo:OHD_0001077 (barium oxide)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001077 "A metal oxide which contain barium and oxigen.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001077 "A metal oxide which contain barium and oxigen."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001077 "PubChem CID	62392
 https://pubchem.ncbi.nlm.nih.gov/compound/62392")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001077 "barium monoxide")
@@ -833,7 +833,7 @@ SubClassOf(obo:OHD_0001077 obo:CHEBI_133331)
 
 # Class: obo:OHD_0001079 (zirconium oxide)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001079 "A metal oxide which contain zirconium and oxygen.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001079 "A metal oxide which contain zirconium and oxygen."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001079 "PubChem CID	6452892
 https://pubchem.ncbi.nlm.nih.gov/compound/Zirconium-oxide")
 AnnotationAssertion(obo:OHD_0008045 obo:OHD_0001079 "oxygen(2-);zirconium(4+)")
@@ -844,7 +844,7 @@ SubClassOf(obo:OHD_0001079 obo:CHEBI_133331)
 
 # Class: obo:OHD_0001080 (yttrium oxide)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001080 "A metal oxide which contains yttrium and oxygen.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001080 "A metal oxide which contains yttrium and oxygen."@en)
 AnnotationAssertion(obo:OHD_0008045 obo:OHD_0001080 "oxygen(2-);yttrium(3+)")
 AnnotationAssertion(terms:contributor obo:OHD_0001080 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001080 "2025-01-30T15:42:14Z"^^xsd:dateTime)
@@ -854,7 +854,7 @@ SubClassOf(obo:OHD_0001080 obo:CHEBI_133331)
 
 # Class: obo:OHD_0001081 (lithium oxide)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001081 "A metal oxide which contain lithium and oxygen.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001081 "A metal oxide which contain lithium and oxygen."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001081 "Compound CID: 166630  
 https://pubchem.ncbi.nlm.nih.gov/compound/166630")
 AnnotationAssertion(obo:OHD_0008045 obo:OHD_0001081 "dilithium;oxygen(2-)")
@@ -874,7 +874,7 @@ SubClassOf(obo:OHD_0001082 obo:OHD_0000000)
 
 # Class: obo:OHD_0001083 (cobalt chromium metal dental resotration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001083 "A predominantly base metal dental restoration material this is primarly composed of cobalt chromium.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001083 "A predominantly base metal dental restoration material this is primarly composed of cobalt chromium."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001083 <http://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0001083 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001083 "2025-06-20T14:52:41Z"^^xsd:dateTime)
@@ -884,7 +884,7 @@ SubClassOf(obo:OHD_0001083 ObjectSomeValuesFrom(obo:RO_0002473 obo:CHEBI_27638))
 
 # Class: obo:OHD_0001084 (nickel chromium metal dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001084 "A predominantly base metal dental restoration material that is primarily composed of nickel chromium.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001084 "A predominantly base metal dental restoration material that is primarily composed of nickel chromium."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001084 <http://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0001084 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001084 "2025-06-20T14:49:56Z"^^xsd:dateTime)
@@ -895,7 +895,7 @@ SubClassOf(obo:OHD_0001084 ObjectSomeValuesFrom(obo:BFO_0000051 obo:CHEBI_28112)
 
 # Class: obo:OHD_0001085 (silver-palladium alloy metal dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001085 "A noble metal dental restoration material that is composed of predominantly silver in composition and at least 25% by weight of palladium to provide nobility of the alloy.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001085 "A noble metal dental restoration material that is composed of predominantly silver in composition and at least 25% by weight of palladium to provide nobility of the alloy."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001085 <http://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0001085 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001085 "2025-06-20T14:47:05Z"^^xsd:dateTime)
@@ -916,7 +916,7 @@ SubClassOf(obo:OHD_0001086 obo:OHD_0000136)
 
 # Class: obo:OHD_0001087 (titanium alloy dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001087 "A titanium dental restoration material that contains titanium with incorporation of alpha or beta microstructural stabilizers. Common microstructural stabilizers include aluminum, vanadium, niobium, cobalt, copper, nickel, or molybdenum.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001087 "A titanium dental restoration material that contains titanium with incorporation of alpha or beta microstructural stabilizers. Common microstructural stabilizers include aluminum, vanadium, niobium, cobalt, copper, nickel, or molybdenum."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001087 <http://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0001087 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001087 "2025-06-20T15:00:37Z"^^xsd:dateTime)

--- a/src/ontology/components/dental_material.owl
+++ b/src/ontology/components/dental_material.owl
@@ -32,7 +32,6 @@ Declaration(Class(obo:OHD_0000001))
 Declaration(Class(obo:OHD_0000034))
 Declaration(Class(obo:OHD_0000036))
 Declaration(Class(obo:OHD_0000048))
-Declaration(Class(obo:OHD_00001025))
 Declaration(Class(obo:OHD_0000135))
 Declaration(Class(obo:OHD_0000136))
 Declaration(Class(obo:OHD_0000137))
@@ -40,6 +39,7 @@ Declaration(Class(obo:OHD_0000146))
 Declaration(Class(obo:OHD_0000147))
 Declaration(Class(obo:OHD_0000156))
 Declaration(Class(obo:OHD_0000191))
+Declaration(Class(obo:OHD_0001000))
 Declaration(Class(obo:OHD_0001005))
 Declaration(Class(obo:OHD_0001006))
 Declaration(Class(obo:OHD_0001007))
@@ -368,7 +368,7 @@ SubClassOf(obo:OHD_0000034 obo:OHD_0000048)
 
 # Class: obo:OHD_0000036 (resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") Annotation(obo:IAO_0000119 "ISBN:0323478212") obo:IAO_0000115 obo:OHD_0000036 "A dental restoration material that is primarily composed of highly cross-linked organic polymeric matrix reinforced by filler particles and/or short fibers bound to the matrix by coupling agents and set by light and or chemically activated polymerization reaction.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") Annotation(obo:IAO_0000119 "ISBN:0323478212") obo:IAO_0000115 obo:OHD_0000036 "A dental restoration material that is primarily composed of highly cross-linked organic polymeric matrix reinforced by filler particles and/or short fibers bound to the matrix by coupling agents and set by light and or chemically activated polymerization reaction."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000036 "Titus Schleyer 3/13/2014: updated definition
 
 Bill D. 08-04-2023: Not all resins are tooth colored. Some are cream colored. Also, updated definition source Craig's restorative Dental Material.")
@@ -385,26 +385,16 @@ AnnotationAssertion(terms:contributor obo:OHD_0000048 <https://orcid.org/0000-00
 AnnotationAssertion(rdfs:label obo:OHD_0000048 "metal dental restoration material"@en)
 SubClassOf(obo:OHD_0000048 obo:OHD_0000000)
 
-# Class: obo:OHD_00001025 (mineral trioxide aggregate cement dental restoration material)
-
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Chang, S.W., 2012. Chemical characteristics of mineral trioxide aggregate and its hydration reaction. 
-Restorative dentistry & endodontics, 37(4), pp.188-193.") obo:IAO_0000115 obo:OHD_00001025 "A dental restoration material that primarily consists of tricalcium silicate, dicalcium silicate (similar to Portland cement), calcium aluminate, gypsum, radiopacifiers and set by hydration of silicates in the presence of moisture.")
-AnnotationAssertion(terms:contributor obo:OHD_00001025 <https://orcid.org/0000-0001-6424-4096>)
-AnnotationAssertion(terms:created obo:OHD_00001025 "2023-10-12T21:52:17Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:comment obo:OHD_00001025 "It is used in pulp capping, apexification, pulpotomy, and treatment of perforation.")
-AnnotationAssertion(rdfs:label obo:OHD_00001025 "mineral trioxide aggregate cement dental restoration material"@en)
-SubClassOf(obo:OHD_00001025 obo:OHD_0000000)
-
 # Class: obo:OHD_0000135 (ceramic dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN: 9780323697552") obo:IAO_0000115 obo:OHD_0000135 "A dental restoration material that has a nonmetallic inorganic structure consisting primarily of compounds containing oxygen combined with one or more metallic or semi-metallic elements that are processed at high temperatures, pressed, and polished or milled.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN: 9780323697552") obo:IAO_0000115 obo:OHD_0000135 "A dental restoration material that has a nonmetallic inorganic structure consisting primarily of compounds containing oxygen combined with one or more metallic or semi-metallic elements that are processed at high temperatures, pressed, and polished or milled."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0000135 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(rdfs:label obo:OHD_0000135 "ceramic dental restoration material"@en)
 SubClassOf(obo:OHD_0000135 obo:OHD_0000000)
 
 # Class: obo:OHD_0000136 (titanium dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000136 "A metal dental restoration material that contains 85% or more titanium.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000136 "A metal dental restoration material that contains 85% or more titanium."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0000136 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000136 "titanium dental restoration material"@en)
 SubClassOf(obo:OHD_0000136 obo:OHD_0000048)
@@ -418,7 +408,7 @@ SubClassOf(obo:OHD_0000137 obo:OHD_0000048)
 
 # Class: obo:OHD_0000146 (noble metal dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000146 "A metal dental restoration material that is composed of a metallic alloy that contains 25% or more (by weight) of noble metal elements.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000146 "A metal dental restoration material that is composed of a metallic alloy that contains 25% or more (by weight) of noble metal elements."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0000146 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:comment obo:OHD_0000146 "Noble metal elements include Gold, Palladium, Platinum, Rhodium, Ruthenium, Iridium, and Osmium.")
 AnnotationAssertion(rdfs:label obo:OHD_0000146 "noble metal dental restoration material"@en)
@@ -426,7 +416,7 @@ SubClassOf(obo:OHD_0000146 obo:OHD_0000048)
 
 # Class: obo:OHD_0000147 (high noble metal dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000147 "A noble metal dental restoration material that is composed of a metallic alloy that contains 40% by weight or more of gold and 60% by weight or more noble metal elements.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000147 "A noble metal dental restoration material that is composed of a metallic alloy that contains 40% by weight or more of gold and 60% by weight or more noble metal elements."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0000147 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:contributor obo:OHD_0000147 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0000147 <https://orcid.org/0009-0002-7282-0836>)
@@ -435,7 +425,7 @@ SubClassOf(obo:OHD_0000147 obo:OHD_0000146)
 
 # Class: obo:OHD_0000156 (predominantly base metal dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000156 "A metal dental restoration material that is composed of group of cast metals that rely on Chromium for corrosion resistance.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1") obo:IAO_0000115 obo:OHD_0000156 "A metal dental restoration material that is composed of group of cast metals that rely on Chromium for corrosion resistance."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0000156 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:contributor obo:OHD_0000156 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000156 "predominantly base metal dental restoration material"@en)
@@ -455,9 +445,19 @@ AnnotationAssertion(terms:contributor obo:OHD_0000191 <https://orcid.org/0000-00
 AnnotationAssertion(terms:contributor obo:OHD_0000191 <https://orcid.org/0000-0003-1829-971X>)
 AnnotationAssertion(rdfs:label obo:OHD_0000191 "dental restoration material role"@en)
 
+# Class: obo:OHD_0001000 (mineral trioxide aggregate cement dental restoration material)
+
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Chang, S.W., 2012. Chemical characteristics of mineral trioxide aggregate and its hydration reaction. 
+Restorative dentistry & endodontics, 37(4), pp.188-193.") obo:IAO_0000115 obo:OHD_0001000 "A dental restoration material that primarily consists of tricalcium silicate, dicalcium silicate (similar to Portland cement), calcium aluminate, gypsum, radiopacifiers and set by hydration of silicates in the presence of moisture."@en)
+AnnotationAssertion(terms:contributor obo:OHD_0001000 <https://orcid.org/0000-0001-6424-4096>)
+AnnotationAssertion(terms:created obo:OHD_0001000 "2023-10-12T21:52:17Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:comment obo:OHD_0001000 "It is used in pulp capping, apexification, pulpotomy, and treatment of perforation.")
+AnnotationAssertion(rdfs:label obo:OHD_0001000 "mineral trioxide aggregate cement dental restoration material"@en)
+SubClassOf(obo:OHD_0001000 obo:OHD_0000000)
+
 # Class: obo:OHD_0001005 (resin-based cement dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:0323478212") Annotation(obo:IAO_0000119 "https://www.iso.org/standard/42898.html") obo:IAO_0000115 obo:OHD_0001005 "A dental restoration material that contains methacrylate monomers, fillers and activator initiator system to facilitate light activated and/or chemically activated polymerization reactions.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:0323478212") Annotation(obo:IAO_0000119 "https://www.iso.org/standard/42898.html") obo:IAO_0000115 obo:OHD_0001005 "A dental restoration material that contains methacrylate monomers, fillers and activator initiator system to facilitate light activated and/or chemically activated polymerization reactions."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001005 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001005 "2023-08-07T15:16:39Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:comment obo:OHD_0001005 "It is intended for use in the cementation or fixation of restorations and appliances.")
@@ -495,7 +495,7 @@ SubClassOf(obo:OHD_0001008 obo:OHD_0000000)
 
 # Class: obo:OHD_0001010 (zinc oxide non-eugenol cement dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:0323478212") Annotation(obo:IAO_0000119 "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9689175/") obo:IAO_0000115 obo:OHD_0001010 "A zinc-oxide cement dental restoration material containing aliphatic acid or butyric acid to substitute the eugenol as a liquid component to complete the acid-base reaction.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN:0323478212") Annotation(obo:IAO_0000119 "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9689175/") obo:IAO_0000115 obo:OHD_0001010 "A zinc-oxide cement dental restoration material containing aliphatic acid or butyric acid to substitute the eugenol as a liquid component to complete the acid-base reaction."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001010 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001010 "2023-07-31T12:05:19Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001010 "zinc oxide non-eugenol cement dental restoration material"@en)
@@ -503,7 +503,7 @@ SubClassOf(obo:OHD_0001010 obo:OHD_0001022)
 
 # Class: obo:OHD_0001011 (bulk-filled resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001011 "A resin-based composite dental restoration material that enables the restoration to be built up in thick layers of up to 4 mm and are recommended by manufacturers to simplify clinical technique and save time compared to traditional incremental placement.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001011 "A resin-based composite dental restoration material that enables the restoration to be built up in thick layers of up to 4 mm and are recommended by manufacturers to simplify clinical technique and save time compared to traditional incremental placement."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001011 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001011 "2023-07-31T12:07:09Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001011 "bulk-filled resin-based composite dental restoration material"@en)
@@ -511,7 +511,7 @@ SubClassOf(obo:OHD_0001011 obo:OHD_0000036)
 
 # Class: obo:OHD_0001012 (flowable resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001012 "A resin-based composite dental restoration material that has low-viscosity and is recommended for cervical lesions, restorations in deciduous teeth, and other small, low- or non-stress bearing restorations.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001012 "A resin-based composite dental restoration material that has low-viscosity and is recommended for cervical lesions, restorations in deciduous teeth, and other small, low- or non-stress bearing restorations."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001012 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001012 "2023-07-31T12:07:24Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001012 "flowable resin-based composite dental restoration material"@en)
@@ -519,7 +519,7 @@ SubClassOf(obo:OHD_0001012 obo:OHD_0000036)
 
 # Class: obo:OHD_0001014 (macrofilled resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001014 "A resin-based composite dental restoration material that contains macrosize filler particles.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001014 "A resin-based composite dental restoration material that contains macrosize filler particles."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001014 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001014 "2023-07-31T12:08:04Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001014 "macrofilled resin-based composite dental restoration material"@en)
@@ -527,7 +527,7 @@ SubClassOf(obo:OHD_0001014 obo:OHD_0000036)
 
 # Class: obo:OHD_0001015 (microfilled resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001015 "A resin-based composite dental restoration material which is composed of dimethacrylate resins with 0.04-m colloidal silica fillers and prepolymerized resins, which are sometimes filled with colloidal silica.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001015 "A resin-based composite dental restoration material which is composed of dimethacrylate resins with 0.04-m colloidal silica fillers and prepolymerized resins, which are sometimes filled with colloidal silica."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001015 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001015 "2023-07-31T12:08:13Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001015 "microfilled resin-based composite dental restoration material"@en)
@@ -535,7 +535,7 @@ SubClassOf(obo:OHD_0001015 obo:OHD_0000036)
 
 # Class: obo:OHD_0001017 (nano filled resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001017 "A resin-based composite dental restoration material that contains nanometer-sized filler particles (1 to 100 nm) throughout the resin matrix.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001017 "A resin-based composite dental restoration material that contains nanometer-sized filler particles (1 to 100 nm) throughout the resin matrix."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001017 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001017 "2023-07-31T12:08:41Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001017 "nano filled resin-based composite dental restoration material"@en)
@@ -543,8 +543,7 @@ SubClassOf(obo:OHD_0001017 obo:OHD_0000036)
 
 # Class: obo:OHD_0001018 (nano hybrid resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001018 "A resin-based composite dental restoration material which consist of large particles 
-(0.4 to 5 m) with added nanometer-sized filler particles. Thus they are hybrid materials, not true nanofilled composites.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") obo:IAO_0000115 obo:OHD_0001018 "A resin-based composite dental restoration material which consist of large particles (0.4 to 5 m) with added nanometer-sized filler particles. Thus they are hybrid materials, not true nanofilled composites."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0001018 "Craig's restorative Dental Material"@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001018 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001018 "2023-07-31T12:08:57Z"^^xsd:dateTime)
@@ -553,7 +552,7 @@ SubClassOf(obo:OHD_0001018 obo:OHD_0000036)
 
 # Class: obo:OHD_0001019 (compomer resin-based composite dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") Annotation(obo:IAO_0000119 "ISBN: 978-1-4377-2418-9") obo:IAO_0000115 obo:OHD_0001019 "A resin-based composite dental restoration material that contains fluoride-releasing silicate glass filler phase and a methacrylate based matrix with carboxylic acid functional groups.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "Craig's restorative Dental Material") Annotation(obo:IAO_0000119 "ISBN: 978-1-4377-2418-9") obo:IAO_0000115 obo:OHD_0001019 "A resin-based composite dental restoration material that contains fluoride-releasing silicate glass filler phase and a methacrylate based matrix with carboxylic acid functional groups."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001019 "polyacid-modified glass ionomer cement")
 AnnotationAssertion(terms:contributor obo:OHD_0001019 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001019 "2023-07-31T12:09:12Z"^^xsd:dateTime)
@@ -602,7 +601,7 @@ SubClassOf(obo:OHD_0001026 obo:OHD_0001021)
 
 # Class: obo:OHD_0001032 (glass matrix ceramic dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "https://doi.org/10.3390/ma16247541") obo:IAO_0000115 obo:OHD_0001032 "A ceramic dental restoration material that contains crystallized ceramic portions which are uniformally distributed within a glass phase.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "https://doi.org/10.3390/ma16247541") obo:IAO_0000115 obo:OHD_0001032 "A ceramic dental restoration material that contains crystallized ceramic portions which are uniformally distributed within a glass phase."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001032 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001032 "2024-08-30T13:39:47Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001032 "glass matrix ceramic dental restoration material"@en)
@@ -619,7 +618,7 @@ SubClassOf(obo:OHD_0001033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0001079)
 
 # Class: obo:OHD_0001034 (zirconia polycrystalline ceramic dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN: 9780323697552") obo:IAO_0000115 obo:OHD_0001034 "A polycrystalline ceramic dental restoration material that contains Zirconia which is partially stabilized zirconium oxide usually in the tetragonal phase.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "ISBN: 9780323697552") obo:IAO_0000115 obo:OHD_0001034 "A polycrystalline ceramic dental restoration material that contains Zirconia which is partially stabilized zirconium oxide usually in the tetragonal phase."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001034 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001034 "2024-08-30T13:42:45Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001034 "zirconia polycrystalline ceramic dental restoration material"@en)
@@ -670,7 +669,7 @@ SubClassOf(obo:OHD_0001039 obo:OHD_0001034)
 
 # Class: obo:OHD_0001040 (polycrystalline composite ceramic dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "doi: 10.3390/ma16247541") obo:IAO_0000115 obo:OHD_0001040 "A polycrystalline ceramic dental restoration material that combines different cryatalline phases to improve specific properties.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "doi: 10.3390/ma16247541") obo:IAO_0000115 obo:OHD_0001040 "A polycrystalline ceramic dental restoration material that combines different cryatalline phases to improve specific properties."@en)
 AnnotationAssertion(terms:contributor obo:OHD_0001040 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001040 "2024-08-30T13:44:39Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0001040 "polycrystalline composite ceramic dental restoration material"@en)
@@ -865,7 +864,7 @@ SubClassOf(obo:OHD_0001081 obo:CHEBI_133331)
 
 # Class: obo:OHD_0001082 (hydroxyethyl methacrylate dental restoration material)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "https://doi.org/10.3390/app14188111") obo:IAO_0000115 obo:OHD_0001082 "A dental restoration material which is a hydrophilic monomer used in dental adhesives, and primers.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "https://doi.org/10.3390/app14188111") obo:IAO_0000115 obo:OHD_0001082 "A dental restoration material which is a hydrophilic monomer used in dental adhesives, and primers."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001082 "HEMA")
 AnnotationAssertion(terms:contributor obo:OHD_0001082 <https://orcid.org/0000-0001-6424-4096>)
 AnnotationAssertion(terms:created obo:OHD_0001082 "2025-03-13T15:59:18Z"^^xsd:dateTime)
@@ -904,8 +903,7 @@ SubClassOf(obo:OHD_0001085 obo:OHD_0000146)
 
 # Class: obo:OHD_0001086 (commercially pure titanium dental restoration material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001086 "A titanium dental restoration material that contain pure titanium with 
-minimum impurities.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0001086 "A titanium dental restoration material that contain pure titanium with minimum impurities."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0001086 "cp-titanium")
 AnnotationAssertion(terms:contributor obo:OHD_0001086 <http://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(terms:contributor obo:OHD_0001086 <https://orcid.org/0000-0001-6424-4096>)

--- a/src/ontology/ohd-edit.owl
+++ b/src/ontology/ohd-edit.owl
@@ -1258,27 +1258,27 @@ Declaration(Datatype(xsd:date))
 
 # Annotation Property: obo:OHD_0000053 (data source)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000053 "An annotation property that relates an individual to the data source that was used to extract information about the individual.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000053 "An annotation property that relates an individual to the data source that was used to extract information about the individual."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000053 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000053 "data source")
+AnnotationAssertion(rdfs:label obo:OHD_0000053 "data source"@en)
 
 # Annotation Property: obo:OHD_0000065 (ADA universal tooth number)
 
 AnnotationAssertion(Annotation(obo:IAO_0000119 "https://www.ada.org/-/media/project/ada-organization/ada/ada-org/files/publications/cdt/ada_utds_value_set_v1_2022_aug.pdf") obo:IAO_0000115 obo:OHD_0000065 "An alternative label for human teeth designated by the American Dental Association."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000065 <https://orcid.org/0009-0002-7282-0836>)
-AnnotationAssertion(rdfs:label obo:OHD_0000065 "ADA universal tooth number")
+AnnotationAssertion(rdfs:label obo:OHD_0000065 "ADA universal tooth number"@en)
 SubAnnotationPropertyOf(obo:OHD_0000065 obo:IAO_0000118)
 
 # Annotation Property: obo:OHD_0000092 (asserted type)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000092 "This annotation is used to indicate that an individual is asserted to be a member of a class.  This is useful when needing to find only the non-inferred type of an individual, and not the all the inferred types.  For example, suppose x is a member of the class 'material entity' and 'material entity' is a subclass of 'independent continuant'.  This entails that x will be a member of 'independent continuant'.  However, by using this annotation to assert that x is a member of 'material entity', you can query for x's 'asserted type' and ignore the other inferred types in the class hierarchy.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000092 "This annotation is used to indicate that an individual is asserted to be a member of a class.  This is useful when needing to find only the non-inferred type of an individual, and not the all the inferred types.  For example, suppose x is a member of the class 'material entity' and 'material entity' is a subclass of 'independent continuant'.  This entails that x will be a member of 'independent continuant'.  However, by using this annotation to assert that x is a member of 'material entity', you can query for x's 'asserted type' and ignore the other inferred types in the class hierarchy."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000092 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:comment obo:OHD_0000092 "Titus Schleyer 1/1/2014: Need to understand this property from an ontological construction perspective.")
-AnnotationAssertion(rdfs:label obo:OHD_0000092 "asserted type")
+AnnotationAssertion(rdfs:label obo:OHD_0000092 "asserted type"@en)
 
 # Annotation Property: obo:OHD_0000209 (duplicated)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000209 "A property indicating whether a representational unit is duplicative of another.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000209 "A property indicating whether a representational unit is duplicative of another."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000209 "This property is an application property, used for intermediate calculations when cleaning data.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000209 "Alan Ruttenberg")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000209 <https://orcid.org/0009-0002-7282-0836>)
@@ -1292,7 +1292,7 @@ SubAnnotationPropertyOf(obo:OHD_0005009 <http://www.geneontology.org/formats/obo
 
 # Annotation Property: obo:OHD_0008081 (ICOP number)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "https://journals.sagepub.com/doi/10.1177/0333102419893823") obo:IAO_0000115 obo:OHD_0008081 "An alternative label for orofacial pain-related terms used by the International Classification of Orofacial Pain (ICOP), 1st edition.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "https://journals.sagepub.com/doi/10.1177/0333102419893823") obo:IAO_0000115 obo:OHD_0008081 "An alternative label for orofacial pain-related terms used by the International Classification of Orofacial Pain (ICOP), 1st edition."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0008081 <https://orcid.org/0009-0002-7282-0836>)
 AnnotationAssertion(dcterms:created obo:OHD_0008081 "2026-06-08T00:48:39Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0008081 "ICOP number"@en)
@@ -1357,7 +1357,7 @@ AnnotationAssertion(rdfs:label <http://www.w3.org/2004/02/skos/core#narrowMatch>
 
 # Object Property: obo:OHD_0000091 (is dental restoration of)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000091 "This relation holds between some restorative material and some part of a tooth in which the restorative material restores or replaces lost tooth structure, oral tissues, tooth (structural) integrity, or tooth functioning.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000091 "This relation holds between some restorative material and some part of a tooth in which the restorative material restores or replaces lost tooth structure, oral tissues, tooth (structural) integrity, or tooth functioning."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000091 "Bill Duncan 6/27/2012:
 This relation is intended to capture the relationship between restorative materials, such as amalagam, and the tooth (or teeth) that is being repaired.  Some examples in which this relation obtains include fillings, crowns, bridges, and inlays. 
 
@@ -1368,12 +1368,12 @@ AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000091 "Adapted from:
 Mosby's Dental Dictionary, 2nd Edition. page 580. 
 Wikipedia: http://en.wikipedia.org/wiki/Dental_restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000091 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000091 "is dental restoration of")
+AnnotationAssertion(rdfs:label obo:OHD_0000091 "is dental restoration of"@en)
 ObjectPropertyRange(obo:OHD_0000091 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001091))
 
 # Object Property: obo:OHD_0000216 (next visit)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000216 "Relates a health care encounter such as a inpatient, outpatient, or hospital stay to the next such encounter for the same patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000216 "Relates a health care encounter such as a inpatient, outpatient, or hospital stay to the next such encounter for the same patient."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000216 "precedes is too general as it doesn't have any constraint on continuity of participants. However it is the case a visit precedes the next one.")
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000216 "relation added as a convenience for survival analysis queries.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000216 "Alan Ruttenberg")
@@ -1382,7 +1382,7 @@ SubObjectPropertyOf(obo:OHD_0000216 obo:OHD_0000217)
 
 # Object Property: obo:OHD_0000217 (later visit)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000217 "Relates a health care encounter such as a inpatient, outpatient, or hospital stay to any subsequent such encounter for the same patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000217 "Relates a health care encounter such as a inpatient, outpatient, or hospital stay to any subsequent such encounter for the same patient."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000217 "relation added as a convenience for survival analysis queries.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000217 "Alan Ruttenberg")
 AnnotationAssertion(rdfs:label obo:OHD_0000217 "later visit"@en)
@@ -1423,7 +1423,7 @@ SubObjectPropertyOf(obo:RO_0002354 obo:RO_0000056)
 
 # Data Property: obo:OHD_0000014 (patient ID)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000014 "A data property that relates an individual patient to the literal string that represents the patient's id.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000014 "A data property that relates an individual patient to the literal string that represents the patient's id."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000014 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000014 "patient ID"@en)
 DataPropertyDomain(obo:OHD_0000014 obo:OHD_0000012)
@@ -1442,7 +1442,7 @@ DataPropertyRange(obo:OHD_0000015 DataUnionOf(xsd:date xsd:dateTime))
 
 # Data Property: obo:OHD_0000050 (birth date)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000050 "A data property that relates an individual to the date on which the individual was born.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000050 "A data property that relates an individual to the date on which the individual was born."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000050 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000050 "birth date"@en)
 SubDataPropertyOf(obo:OHD_0000050 owl:topDataProperty)
@@ -1451,31 +1451,31 @@ DataPropertyRange(obo:OHD_0000050 DataUnionOf(xsd:date xsd:dateTime))
 
 # Data Property: obo:OHD_0000097 (has patient activity status)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000097 "A data property in which the values provide information as to whether a patient is actively being cared for by the practicet; takes values \"active\" and \"inactive\".")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000097 "A data property in which the values provide information as to whether a patient is actively being cared for by the practicet; takes values \"active\" and \"inactive\"."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000097 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000097 "2022-12-06T01:11:57Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0000097 "has patient activity status")
+AnnotationAssertion(rdfs:label obo:OHD_0000097 "has patient activity status"@en)
 DataPropertyRange(obo:OHD_0000097 xsd:string)
 
 # Data Property: obo:OHD_0000218 (first dental visit date)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000218 "A data property used to record the date of a patient's first dental visit.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000218 "A data property used to record the date of a patient's first dental visit."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000218 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000218 "2022-12-06T01:22:17Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0000218 "first dental visit date")
+AnnotationAssertion(rdfs:label obo:OHD_0000218 "first dental visit date"@en)
 DataPropertyRange(obo:OHD_0000218 DataUnionOf(xsd:date xsd:dateTime))
 
 # Data Property: obo:OHD_0000219 (last dental visit date)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000219 "A data property used to record the last date on which a patient had a dental visit.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000219 "A data property used to record the last date on which a patient had a dental visit."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000219 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000219 "2022-12-06T01:23:31Z"^^xsd:dateTime)
-AnnotationAssertion(rdfs:label obo:OHD_0000219 "last dental visit date")
+AnnotationAssertion(rdfs:label obo:OHD_0000219 "last dental visit date"@en)
 DataPropertyRange(obo:OHD_0000219 DataUnionOf(xsd:date xsd:dateTime))
 
 # Data Property: obo:OHD_0000234 (missing tooth number)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000234 "A data property whose value is an ADA universal tooth number that represents a tooth which is missing from a dentition.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000234 "A data property whose value is an ADA universal tooth number that represents a tooth which is missing from a dentition."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000234 "Bill Duncan 01/03/2017:
 This data property provides a means to query for missing teeth. Since a missing tooth is not a tooth, it is wrong represent a missing tooth as an instance of a tooth. Rather, we represent a missing tooth by respresenting the instance of the dentition and then specify with this data property that the dentition is missing a tooth designated by the universtal tooth number.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000234 <https://orcid.org/0000-0001-9625-1899>)
@@ -1484,7 +1484,7 @@ DataPropertyRange(obo:OHD_0000234 xsd:string)
 
 # Data Property: obo:OHD_0000360 (missing tooth root number)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000360 "A data property whose value is an ADA universal tooth number that represents the tooth associated with a tooth root that is missing from a dentition.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000360 "A data property whose value is an ADA universal tooth number that represents the tooth associated with a tooth root that is missing from a dentition."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000360 "Bill Duncan 10/18/2017:
 This data property provides a means to query for missing tooth roots. Since a missing tooth root is not a tooth root, it is wrong represent a missing tooth root as an instance of a tooth root. Rather, we represent a missing tooth root by respresenting the instance of the dentition and then specify with this data property that the dentition is missing a tooth root that is associated with the tooth designated by the universtal tooth number.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000360 <https://orcid.org/0000-0001-9625-1899>)
@@ -1953,7 +1953,7 @@ SubClassOf(obo:OHD_0000000 obo:OBI_0000047)
 
 # Class: obo:OHD_0000002 (dental procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000002 "A healthcare encounter that realizes a dental patient role in which the patient undergoes a diagnostic or therapeutic process.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000002 "A healthcare encounter that realizes a dental patient role in which the patient undergoes a diagnostic or therapeutic process."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000002 "Bill Duncan 5/12/2015:
 
 Changed \"A specific healthcare activity\" to \"A health care encounter in which\"")
@@ -1968,7 +1968,7 @@ SubClassOf(obo:OHD_0000002 ObjectSomeValuesFrom(obo:RO_0002092 obo:OHD_0000009))
 
 # Class: obo:OHD_0000003 (endodontic procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000003 "A dental procedure that is performed on the pulp chamber and/or root canal of a tooth, or a part thereof.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000003 "A dental procedure that is performed on the pulp chamber and/or root canal of a tooth, or a part thereof."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000003 "Titus Schleyer 1/14/2014: adapted definition")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000003 "PERSON:Pedro Cott")
 AnnotationAssertion(rdfs:label obo:OHD_0000003 "endodontic procedure"@en)
@@ -1978,7 +1978,7 @@ SubClassOf(obo:OHD_0000003 ObjectSomeValuesFrom(obo:RO_0000057 obo:UBERON_000109
 
 # Class: obo:OHD_0000004 (tooth restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000004 "A dental procedure in which either a whole tooth or a part of a tooth is replaced by dental restoration material in order to reestablish the tooth's anatomical and functional form and function.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000004 "A dental procedure in which either a whole tooth or a part of a tooth is replaced by dental restoration material in order to reestablish the tooth's anatomical and functional form and function."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000004 "Bill Duncan 12/16/2014:
 Updated definition. 
 
@@ -2009,7 +2009,7 @@ SubClassOf(obo:OHD_0000004 ObjectSomeValuesFrom(obo:RO_0000057 obo:UBERON_000109
 
 # Class: obo:OHD_0000005 (surgical procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000005 "A series of steps followed in a regular, orderly, definite way, performed by a physician, dentist or surgeon by manual operation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000005 "A series of steps followed in a regular, orderly, definite way, performed by a physician, dentist or surgeon by manual operation."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000005 "Titus Schleyer 3/4/2014: adapted definition")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000005 "PERSON:Pedro Cott")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000005 "Mosby's Dental Dictionary 2nd ed")
@@ -2018,7 +2018,7 @@ SubClassOf(obo:OHD_0000005 obo:OGMS_0000097)
 
 # Class: obo:OHD_0000006 (intracoronal restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000006 "A tooth restoration procedure in which a dental restoration material is placed into a site that is located in the crown of the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000006 "A tooth restoration procedure in which a dental restoration material is placed into a site that is located in the crown of the tooth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000006 "Titus Schleyer 1/14/2014: updated definition")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000006 "PERSON: Alan Ruttenberg")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000006 "filling restoration")
@@ -2028,24 +2028,24 @@ SubClassOf(obo:OHD_0000006 obo:OHD_0000004)
 
 # Class: obo:OHD_0000007 (tooth to be restored role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000007 "A target of material addition role that inheres in a tooth and is realized by a tooth restoration procedure during which the tooth bearing the role is restored to health.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000007 "A target of material addition role that inheres in a tooth and is realized by a tooth restoration procedure during which the tooth bearing the role is restored to health."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000007 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000007 "tooth to be restored role")
+AnnotationAssertion(rdfs:label obo:OHD_0000007 "tooth to be restored role"@en)
 SubClassOf(obo:OHD_0000007 obo:OBI_0000444)
 SubClassOf(obo:OHD_0000007 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:BFO_0000052 obo:OHD_0000206) ObjectAllValuesFrom(obo:BFO_0000052 obo:OHD_0000206)))
 SubClassOf(obo:OHD_0000007 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000004))
 
 # Class: obo:OHD_0000008 (tooth to be filled role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000008 "A tooth to be restored role that is realized by an intracoronal restoration procedure")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000008 "A tooth to be restored role that is realized by an intracoronal restoration procedure"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000008 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000008 "tooth to be filled role")
+AnnotationAssertion(rdfs:label obo:OHD_0000008 "tooth to be filled role"@en)
 EquivalentClasses(obo:OHD_0000008 ObjectIntersectionOf(obo:OHD_0000007 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000006)))
 SubClassOf(obo:OHD_0000008 obo:OHD_0000007)
 
 # Class: obo:OHD_0000009 (dental visit)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000009 "An outpatient encounter during which a dental health care professional and a patient meet for the purpose of evaluating, treating disorders of, or preventing deterioration of the patient's oral health.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000009 "An outpatient encounter during which a dental health care professional and a patient meet for the purpose of evaluating, treating disorders of, or preventing deterioration of the patient's oral health."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000009 "Titus Schleyer 1/14/14: adapted definition")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000009 "PERSON:Alan Ruttenberg")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000009 "Adapted from Mosby's Dental Dictionary")
@@ -2083,7 +2083,7 @@ SubClassOf(obo:OHD_0000011 ObjectIntersectionOf(obo:OGMS_0000104 ObjectSomeValue
 
 # Class: obo:OHD_0000012 (human dental patient)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000012 "A Homo sapiens that bears some dental patient role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000012 "A Homo sapiens that bears some dental patient role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000012 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000012 "human dental patient"@en)
 EquivalentClasses(obo:OHD_0000012 ObjectIntersectionOf(obo:NCBITaxon_9606 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000190)))
@@ -2100,12 +2100,12 @@ SubClassOf(obo:OHD_0000013 obo:OBI_0000245)
 
 # Class: obo:OHD_0000016 (dental hygienist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000016 "A dental health care provider role that inheres in a person who is a licensed dental professional that specializes in preventative care.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000016 "A dental health care provider role that inheres in a person who is a licensed dental professional that specializes in preventative care."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000016 "Bill Duncan 09/30/2015:
 Professional prophylaxis, radiographs, sealants, and nonsurgical periodontal therapy are among the procedures performed by a hygienist. Most are licensed to administer local anesthesia, depending on applicable regulations in their area. They usually work for a dentist in a dental office or clinic under a form of supervision. In some locations hygienists are allowed to practice without a dentist's supervision.")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000016 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 325.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000016 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000016 "dental hygienist role")
+AnnotationAssertion(rdfs:label obo:OHD_0000016 "dental hygienist role"@en)
 SubClassOf(obo:OHD_0000016 obo:OHD_0000052)
 
 # Class: obo:OHD_0000017 (dentist role)
@@ -2114,14 +2114,14 @@ AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000017 "A dental health care provid
 .")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000017 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 173.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000017 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000017 "dentist role")
+AnnotationAssertion(rdfs:label obo:OHD_0000017 "dentist role"@en)
 SubClassOf(obo:OHD_0000017 obo:OHD_0000052)
 
 # Class: obo:OHD_0000018 (dentist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000018 "A dental health care provider that bears a dentist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000018 "A dental health care provider that bears a dentist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000018 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000018 "dentist")
+AnnotationAssertion(rdfs:label obo:OHD_0000018 "dentist"@en)
 EquivalentClasses(obo:OHD_0000018 ObjectIntersectionOf(obo:OHD_0000051 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000017)))
 SubClassOf(obo:OHD_0000018 obo:OHD_0000051)
 
@@ -2139,15 +2139,15 @@ SubClassOf(obo:OHD_0000019 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000010)
 
 # Class: obo:OHD_0000020 (dental hygienist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000020 "A dental health care provider that bears a dental hygienist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000020 "A dental health care provider that bears a dental hygienist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000020 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000020 "dental hygienist")
+AnnotationAssertion(rdfs:label obo:OHD_0000020 "dental hygienist"@en)
 EquivalentClasses(obo:OHD_0000020 ObjectIntersectionOf(obo:OHD_0000051 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000016)))
 SubClassOf(obo:OHD_0000020 obo:OHD_0000051)
 
 # Class: obo:OHD_0000021 (carious tooth lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000021 "A tooth disorder that affects a tooth that includes both the infectious organisms, the material they generate from the tooth, any immune effectors that are a response to the presence of the disorder and the physical changes to the tooth (i.e., demineralization or a cavity) resulting from the disorder. It is the physical basis for the disease \"dental caries.\"")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000021 "A tooth disorder that affects a tooth that includes both the infectious organisms, the material they generate from the tooth, any immune effectors that are a response to the presence of the disorder and the physical changes to the tooth (i.e., demineralization or a cavity) resulting from the disorder. It is the physical basis for the disease \"dental caries.\""@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000021 "Titus Schleyer 1/14/2014: updated definition")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000021 "Titus Schleyer")
 AnnotationAssertion(rdfs:comment obo:OHD_0000021 "is caries a material entity or a quality?")
@@ -2158,16 +2158,16 @@ SubClassOf(obo:OHD_0000021 ObjectSomeValuesFrom(obo:RO_0002354 obo:OHD_0000442))
 
 # Class: obo:OHD_0000022 (metallic inlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000022 "An inlay restoration procedure that uses metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000022 "An inlay restoration procedure that uses metal to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000022 "metallic inlay restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000022 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000022 "metallic inlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000022 "metallic inlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000022 ObjectIntersectionOf(obo:OHD_0000133 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000048)))
 SubClassOf(obo:OHD_0000022 obo:OHD_0000133)
 
 # Class: obo:OHD_0000023 (restored tooth finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000023 "A dental finding that a tooth has been restored.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000023 "A dental finding that a tooth has been restored."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000023 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000023 "2022-12-06T01:37:27Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000023 "restored tooth finding"@en)
@@ -2176,7 +2176,7 @@ SubClassOf(obo:OHD_0000023 obo:OHD_0000010)
 
 # Class: obo:OHD_0000024 (caries finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000024 "A dental finding that indicates a carious lesion of a tooth")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000024 "A dental finding that indicates a carious lesion of a tooth"@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000024 "Titus Schleyer 1/14/2014: How about this as an alternative definition: \"A dental finding that indicates a carious lesion of a tooth\"?")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000024 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000024 "caries finding"@en)
@@ -2208,16 +2208,16 @@ SubClassOf(obo:OHD_0000026 ObjectExactCardinality(1 obo:IAO_0000136 obo:UBERON_0
 
 # Class: obo:OHD_0000027 (veneer restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000027 "A tooth restoration procedure in which a thin layer of material (i.e., a veneer) is placed over one or more surfaces of the tooth either to improve the aesthetics of the tooth or to protect the tooth's surface from damage")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000027 "A tooth restoration procedure in which a thin layer of material (i.e., a veneer) is placed over one or more surfaces of the tooth either to improve the aesthetics of the tooth or to protect the tooth's surface from damage"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000027 "Adapted from Wikipedia:
 http://en.wikipedia.org/wiki/Veneer_%28dentistry%29")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000027 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000027 "veneer restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000027 "veneer restoration procedure"@en)
 SubClassOf(obo:OHD_0000027 obo:OHD_0000004)
 
 # Class: obo:OHD_0000028 (missing tooth 14 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000028 "A missing tooth finding in which tooth 14 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000028 "A missing tooth finding in which tooth 14 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000028 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000028 "missing tooth 14 finding"@en)
 SubClassOf(obo:OHD_0000028 obo:OHD_0000026)
@@ -2256,14 +2256,14 @@ SubClassOf(obo:OHD_0000031 ObjectSomeValuesFrom(obo:RO_0004020 obo:OHD_0000420))
 
 # Class: obo:OHD_0000032 (soft tissue exam)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000032 "A dental exam which focuses on soft tissue in and near the mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000032 "A dental exam which focuses on soft tissue in and near the mouth."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000032 "Alan Ruttenberg")
 AnnotationAssertion(rdfs:label obo:OHD_0000032 "soft tissue exam"@en)
 SubClassOf(obo:OHD_0000032 obo:OHD_0000019)
 
 # Class: obo:OHD_0000033 (crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000033 "A tooth restoration procedure whereby an artificial crown replaces all or part of the natural dental crown.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000033 "A tooth restoration procedure whereby an artificial crown replaces all or part of the natural dental crown."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000033 "Titus Schleyer 1/14/2014: adapted definition")
 AnnotationAssertion(rdfs:label obo:OHD_0000033 "crown restoration procedure"@en)
 SubClassOf(obo:OHD_0000033 obo:OHD_0000004)
@@ -2271,13 +2271,13 @@ SubClassOf(obo:OHD_0000033 obo:OHD_0000004)
 # Class: obo:OHD_0000035 (obsolete porcelain dental restoration material)
 
 AnnotationAssertion(obo:IAO_0100001 obo:OHD_0000035 obo:OHD_0000135)
-AnnotationAssertion(rdfs:label obo:OHD_0000035 "obsolete porcelain dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000035 "obsolete porcelain dental restoration material"@en)
 AnnotationAssertion(owl:deprecated obo:OHD_0000035 "true"^^xsd:boolean)
 SubClassOf(obo:OHD_0000035 <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: obo:OHD_0000037 (direct dental material insertion process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000037 "A material combination in which a moldable restorative material is placed directly into or on the tooth. The material then hardens and becomes (essentially) part of the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000037 "A material combination in which a moldable restorative material is placed directly into or on the tooth. The material then hardens and becomes (essentially) part of the tooth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000037 "Bill Duncan 12/11/2014:
 Moved from this class from being a subtype of tooth restoration procedure to being a subclass of material combination.")
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000037 "Titus Schleyer 1/1/2014: made definition clearer")
@@ -2288,7 +2288,7 @@ SubClassOf(obo:OHD_0000037 ObjectSomeValuesFrom(obo:OBI_0000293 obo:UBERON_00010
 
 # Class: obo:OHD_0000038 (dental material tooth attachment process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000038 "A material combination in which a rigid piece of restoration material is attached to a tooth. The restoration is attached to the tooth by mechanical forces or some form of cement or glue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000038 "A material combination in which a rigid piece of restoration material is attached to a tooth. The restoration is attached to the tooth by mechanical forces or some form of cement or glue."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000038 "Bill Duncan 12/11/2014:
 Moved from this class from being a subtype of tooth restoration procedure to being a subclass of material combination.")
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000038 "Bill Duncan 12/16/2014:
@@ -2308,45 +2308,45 @@ SubClassOf(obo:OHD_0000038 ObjectSomeValuesFrom(obo:OBI_0000293 obo:UBERON_00010
 
 # Class: obo:OHD_0000039 (gold filling restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000039 "An intracoronal restoration procedure that uses gold foil to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000039 "An intracoronal restoration procedure that uses gold foil to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000039 "gold filling restoration")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000039 "gold foil intracoronal restoration procedure")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000039 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000039 "gold filling restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000039 "gold filling restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000039 ObjectIntersectionOf(obo:OHD_0000006 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000034)))
 SubClassOf(obo:OHD_0000039 obo:OHD_0000006)
 
 # Class: obo:OHD_0000040 (3/4 noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000040 "A 3/4 crown restoration procedure that uses noble metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000040 "A 3/4 crown restoration procedure that uses noble metal to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000040 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000040 "3/4 noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000040 "3/4 noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000040 ObjectIntersectionOf(obo:OHD_0000305 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000146)))
 SubClassOf(obo:OHD_0000040 obo:OHD_0000305)
 
 # Class: obo:OHD_0000041 (amalgam filling restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000041 "An intracoronal restoration procedure that uses amalgam to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000041 "An intracoronal restoration procedure that uses amalgam to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000041 "amalgam filling restoration")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000041 "amalgam intracoronal restoration procedure")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000041 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000041 "amalgam filling restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000041 "amalgam filling restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000041 ObjectIntersectionOf(obo:OHD_0000006 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000037) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000001)))
 SubClassOf(obo:OHD_0000041 obo:OHD_0000006)
 
 # Class: obo:OHD_0000042 (resin filling restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000042 "An intracoronal restoration procedure that uses resin to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000042 "An intracoronal restoration procedure that uses resin to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000042 "resin filling restoration")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000042 "resin intracoronal restoration procedure")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000042 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000042 "resin filling restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000042 "resin filling restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000042 ObjectIntersectionOf(obo:OHD_0000006 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000037) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036)))
 SubClassOf(obo:OHD_0000042 obo:OHD_0000006)
 
 # Class: obo:OHD_0000043 (dentin hypersensitivity)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "PMID:24724135") obo:IAO_0000115 obo:OHD_0000043 "A disposition of the tooth that is realized in an experience of pain derived from exposed dentin.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "PMID:24724135") obo:IAO_0000115 obo:OHD_0000043 "A disposition of the tooth that is realized in an experience of pain derived from exposed dentin."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000043 <https://orcid.org/0000-0001-6378-1703>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000043 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000043 <https://orcid.org/0000-0001-9990-8331>)
@@ -2361,7 +2361,7 @@ SubClassOf(obo:OHD_0000043 ObjectSomeValuesFrom(obo:RO_0000052 obo:OHD_0000410))
 
 # Class: obo:OHD_0000044 (surgical dental procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000044 "A dental procedure that consists of series of steps followed in a regular, orderly, definite way, performed by a dentist or dental surgeon by manual operation on some part of the mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000044 "A dental procedure that consists of series of steps followed in a regular, orderly, definite way, performed by a dentist or dental surgeon by manual operation on some part of the mouth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000044 "Titus Schleyer 1/14/14:checked definition, adapted it slightly")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000044 "Mosby's Dental Dictionary 2nd ed")
 AnnotationAssertion(rdfs:label obo:OHD_0000044 "surgical dental procedure"@en)
@@ -2369,41 +2369,41 @@ SubClassOf(obo:OHD_0000044 obo:OHD_0000002)
 
 # Class: obo:OHD_0000045 (resin laminate veneer restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000045 "A veneer restoration procedure that uses resin laminate to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000045 "A veneer restoration procedure that uses resin laminate to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000045 "resin laminate veneer restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000045 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000045 "resin laminate veneer restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000045 "resin laminate veneer restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000045 ObjectIntersectionOf(obo:OHD_0000027 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036)))
 SubClassOf(obo:OHD_0000045 obo:OHD_0000027)
 
 # Class: obo:OHD_0000046 (porcelain laminate veneer restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000046 "A veneer restoration procedure that uses porcelain laminate to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000046 "A veneer restoration procedure that uses porcelain laminate to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000046 "porcelain laminate veneer restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000046 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000046 "porcelain laminate veneer restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000046 "porcelain laminate veneer restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000046 ObjectIntersectionOf(obo:OHD_0000027 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135)))
 SubClassOf(obo:OHD_0000046 obo:OHD_0000027)
 
 # Class: obo:OHD_0000047 (tooth to undergo veneer procedure role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000047 "A tooth to be restored role that is realized by a veneer restoration procedure")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000047 "A tooth to be restored role that is realized by a veneer restoration procedure"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000047 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000047 "tooth to undergo veneer procedure role")
+AnnotationAssertion(rdfs:label obo:OHD_0000047 "tooth to undergo veneer procedure role"@en)
 EquivalentClasses(obo:OHD_0000047 ObjectIntersectionOf(obo:OHD_0000007 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000027)))
 SubClassOf(obo:OHD_0000047 obo:OHD_0000007)
 
 # Class: obo:OHD_0000049 (female dental patient)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000049 "A human dental patient that bears a female gender role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000049 "A human dental patient that bears a female gender role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000049 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000049 "female dental patient")
+AnnotationAssertion(rdfs:label obo:OHD_0000049 "female dental patient"@en)
 EquivalentClasses(obo:OHD_0000049 ObjectIntersectionOf(obo:OHD_0000012 ObjectSomeValuesFrom(obo:RO_0000087 obo:OMRSE_00000009)))
 SubClassOf(obo:OHD_0000049 obo:OHD_0000012)
 
 # Class: obo:OHD_0000051 (dental healthcare provider)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000051 "A health care provider that bears a dental health care provider role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000051 "A health care provider that bears a dental health care provider role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000051 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000051 "dental healthcare provider"@en)
 EquivalentClasses(obo:OHD_0000051 ObjectIntersectionOf(obo:OHD_0000179 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000052)))
@@ -2411,7 +2411,7 @@ SubClassOf(obo:OHD_0000051 obo:OHD_0000179)
 
 # Class: obo:OHD_0000052 (dental healthcare provider role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000052 "A health care provider role that inheres in a person who is licensed to provide dental health care.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000052 "A health care provider role that inheres in a person who is licensed to provide dental health care."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000052 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000052 "dental healthcare provider role"@en)
 SubClassOf(obo:OHD_0000052 obo:OHD_0000212)
@@ -2420,347 +2420,347 @@ SubClassOf(obo:OHD_0000052 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000002)
 
 # Class: obo:OHD_0000054 (male dental patient)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000054 "A human dental patient that bears a male gender role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000054 "A human dental patient that bears a male gender role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000054 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000054 "male dental patient")
+AnnotationAssertion(rdfs:label obo:OHD_0000054 "male dental patient"@en)
 EquivalentClasses(obo:OHD_0000054 ObjectIntersectionOf(obo:OHD_0000012 ObjectSomeValuesFrom(obo:RO_0000087 obo:OMRSE_00000008)))
 SubClassOf(obo:OHD_0000054 obo:OHD_0000012)
 
 # Class: obo:OHD_0000055 (tooth to be crowned role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000055 "A tooth to be restored role that is realized by a crown restoration procedure")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000055 "A tooth to be restored role that is realized by a crown restoration procedure"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000055 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000055 "tooth to be crowned role")
+AnnotationAssertion(rdfs:label obo:OHD_0000055 "tooth to be crowned role"@en)
 EquivalentClasses(obo:OHD_0000055 ObjectIntersectionOf(obo:OHD_0000007 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000033)))
 SubClassOf(obo:OHD_0000055 obo:OHD_0000007)
 
 # Class: obo:OHD_0000056 (tooth to be extracted role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000056 "A role that inheres in a tooth and is realized by a tooth extraction procedure during which the tooth bearing the role is extracted.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000056 "A role that inheres in a tooth and is realized by a tooth extraction procedure during which the tooth bearing the role is extracted."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000056 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000056 "tooth to be extracted role")
+AnnotationAssertion(rdfs:label obo:OHD_0000056 "tooth to be extracted role"@en)
 SubClassOf(obo:OHD_0000056 obo:BFO_0000023)
 SubClassOf(obo:OHD_0000056 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:BFO_0000052 obo:OHD_0000206) ObjectAllValuesFrom(obo:BFO_0000052 obo:OHD_0000206)))
 SubClassOf(obo:OHD_0000056 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000057))
 
 # Class: obo:OHD_0000057 (tooth extraction procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000057 "A surgical dental procedure that removes a tooth from the oral cavity.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000057 "A surgical dental procedure that removes a tooth from the oral cavity."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000057 "Titus Schleyer 1/14/2014: 
 I think the instrumentation (\" ...  by means of elevators and/or forceps\")  is not relevant to this definition.  I have extracted certain teeth with two fingers.")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000057 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 102007. p. 238")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000057 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000057 "tooth extraction procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000057 "tooth extraction procedure"@en)
 SubClassOf(obo:OHD_0000057 obo:OHD_0000044)
 SubClassOf(obo:OHD_0000057 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000233))
 SubClassOf(obo:OHD_0000057 ObjectSomeValuesFrom(obo:RO_0000057 obo:UBERON_0001091))
 
 # Class: obo:OHD_0000058 (tooth to undergo endodontic procedure role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000058 "A role that inheres in a tooth and is realized by an endodontic procedure performed on the tooth bearing the role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000058 "A role that inheres in a tooth and is realized by an endodontic procedure performed on the tooth bearing the role."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000058 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000058 "tooth to undergo endodontic procedure role")
+AnnotationAssertion(rdfs:label obo:OHD_0000058 "tooth to undergo endodontic procedure role"@en)
 SubClassOf(obo:OHD_0000058 obo:BFO_0000023)
 SubClassOf(obo:OHD_0000058 ObjectSomeValuesFrom(obo:BFO_0000052 obo:OHD_0000206))
 SubClassOf(obo:OHD_0000058 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000003))
 
 # Class: obo:OHD_0000059 (missing tooth 1 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000059 "A missing tooth finding in which tooth 1 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000059 "A missing tooth finding in which tooth 1 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000059 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000059 "missing tooth 1 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000059 "missing tooth 1 finding"@en)
 SubClassOf(obo:OHD_0000059 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000059 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490000)))))
 
 # Class: obo:OHD_0000060 (missing tooth 2 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000060 "A missing tooth finding in which tooth 2 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000060 "A missing tooth finding in which tooth 2 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000060 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000060 "missing tooth 2 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000060 "missing tooth 2 finding"@en)
 SubClassOf(obo:OHD_0000060 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000060 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490001)))))
 
 # Class: obo:OHD_0000061 (missing tooth 3 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000061 "A missing tooth finding in which tooth 3 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000061 "A missing tooth finding in which tooth 3 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000061 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000061 "missing tooth 3 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000061 "missing tooth 3 finding"@en)
 SubClassOf(obo:OHD_0000061 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000061 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490002)))))
 
 # Class: obo:OHD_0000062 (missing tooth 4 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000062 "A missing tooth finding in which tooth 4 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000062 "A missing tooth finding in which tooth 4 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000062 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000062 "missing tooth 4 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000062 "missing tooth 4 finding"@en)
 SubClassOf(obo:OHD_0000062 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000062 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490003)))))
 
 # Class: obo:OHD_0000063 (missing tooth 5 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000063 "A missing tooth finding in which tooth 5 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000063 "A missing tooth finding in which tooth 5 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000063 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000063 "missing tooth 5 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000063 "missing tooth 5 finding"@en)
 SubClassOf(obo:OHD_0000063 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000063 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490004)))))
 
 # Class: obo:OHD_0000064 (missing tooth 6 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000064 "A missing tooth finding in which tooth 6 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000064 "A missing tooth finding in which tooth 6 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000064 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000064 "missing tooth 6 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000064 "missing tooth 6 finding"@en)
 SubClassOf(obo:OHD_0000064 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000064 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490005)))))
 
 # Class: obo:OHD_0000066 (missing tooth 7 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000066 "A missing tooth finding in which tooth 7 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000066 "A missing tooth finding in which tooth 7 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000066 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000066 "missing tooth 7 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000066 "missing tooth 7 finding"@en)
 SubClassOf(obo:OHD_0000066 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000066 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490006)))))
 
 # Class: obo:OHD_0000067 (missing tooth 8 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000067 "A missing tooth finding in which tooth 8 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000067 "A missing tooth finding in which tooth 8 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000067 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000067 "missing tooth 8 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000067 "missing tooth 8 finding"@en)
 SubClassOf(obo:OHD_0000067 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000067 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490007)))))
 
 # Class: obo:OHD_0000068 (missing tooth 9 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000068 "A missing tooth finding in which tooth 9 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000068 "A missing tooth finding in which tooth 9 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000068 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000068 "missing tooth 9 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000068 "missing tooth 9 finding"@en)
 SubClassOf(obo:OHD_0000068 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000068 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490033)))))
 
 # Class: obo:OHD_0000069 (missing tooth 10 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000069 "A missing tooth finding in which tooth 10 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000069 "A missing tooth finding in which tooth 10 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000069 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000069 "missing tooth 10 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000069 "missing tooth 10 finding"@en)
 SubClassOf(obo:OHD_0000069 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000069 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490032)))))
 
 # Class: obo:OHD_0000070 (missing tooth 11 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000070 "A missing tooth finding in which tooth 11 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000070 "A missing tooth finding in which tooth 11 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000070 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000070 "missing tooth 11 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000070 "missing tooth 11 finding"@en)
 SubClassOf(obo:OHD_0000070 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000070 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490031)))))
 
 # Class: obo:OHD_0000071 (missing tooth 12 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000071 "A missing tooth finding in which tooth 12 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000071 "A missing tooth finding in which tooth 12 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000071 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000071 "missing tooth 12 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000071 "missing tooth 12 finding"@en)
 SubClassOf(obo:OHD_0000071 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000071 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490030)))))
 
 # Class: obo:OHD_0000072 (missing tooth 13 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000072 "A missing tooth finding in which tooth 13 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000072 "A missing tooth finding in which tooth 13 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000072 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000072 "missing tooth 13 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000072 "missing tooth 13 finding"@en)
 SubClassOf(obo:OHD_0000072 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000072 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490029)))))
 
 # Class: obo:OHD_0000073 (missing tooth 15 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000073 "A missing tooth finding in which tooth 15 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000073 "A missing tooth finding in which tooth 15 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000073 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000073 "missing tooth 15 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000073 "missing tooth 15 finding"@en)
 SubClassOf(obo:OHD_0000073 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000073 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490027)))))
 
 # Class: obo:OHD_0000074 (missing tooth 16 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000074 "A missing tooth finding in which tooth 16 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000074 "A missing tooth finding in which tooth 16 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000074 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000074 "missing tooth 16 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000074 "missing tooth 16 finding"@en)
 SubClassOf(obo:OHD_0000074 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000074 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490026)))))
 
 # Class: obo:OHD_0000075 (missing tooth 17 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000075 "A missing tooth finding in which tooth 17 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000075 "A missing tooth finding in which tooth 17 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000075 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000075 "missing tooth 17 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000075 "missing tooth 17 finding"@en)
 SubClassOf(obo:OHD_0000075 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000075 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490034)))))
 
 # Class: obo:OHD_0000076 (missing tooth 18 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000076 "A missing tooth finding in which tooth 18 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000076 "A missing tooth finding in which tooth 18 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000076 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000076 "missing tooth 18 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000076 "missing tooth 18 finding"@en)
 SubClassOf(obo:OHD_0000076 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000076 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490035)))))
 
 # Class: obo:OHD_0000077 (missing tooth 19 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000077 "A missing tooth finding in which tooth 19 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000077 "A missing tooth finding in which tooth 19 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000077 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000077 "missing tooth 19 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000077 "missing tooth 19 finding"@en)
 SubClassOf(obo:OHD_0000077 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000077 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490036)))))
 
 # Class: obo:OHD_0000078 (missing tooth 20 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000078 "A missing tooth finding in which tooth 20 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000078 "A missing tooth finding in which tooth 20 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000078 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000078 "missing tooth 20 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000078 "missing tooth 20 finding"@en)
 SubClassOf(obo:OHD_0000078 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000078 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490037)))))
 
 # Class: obo:OHD_0000079 (missing tooth 21 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000079 "A missing tooth finding in which tooth 21 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000079 "A missing tooth finding in which tooth 21 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000079 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000079 "missing tooth 21 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000079 "missing tooth 21 finding"@en)
 SubClassOf(obo:OHD_0000079 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000079 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490038)))))
 
 # Class: obo:OHD_0000080 (missing tooth 22 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000080 "A missing tooth finding in which tooth 22 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000080 "A missing tooth finding in which tooth 22 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000080 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000080 "missing tooth 22 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000080 "missing tooth 22 finding"@en)
 SubClassOf(obo:OHD_0000080 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000080 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490039)))))
 
 # Class: obo:OHD_0000081 (missing tooth 23 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000081 "A missing tooth finding in which tooth 23 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000081 "A missing tooth finding in which tooth 23 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000081 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000081 "missing tooth 23 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000081 "missing tooth 23 finding"@en)
 SubClassOf(obo:OHD_0000081 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000081 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490040)))))
 
 # Class: obo:OHD_0000082 (missing tooth 24 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000082 "A missing tooth finding in which tooth 24 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000082 "A missing tooth finding in which tooth 24 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000082 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000082 "missing tooth 24 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000082 "missing tooth 24 finding"@en)
 SubClassOf(obo:OHD_0000082 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000082 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490041)))))
 
 # Class: obo:OHD_0000083 (missing tooth 25 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000083 "A missing tooth finding in which tooth 25 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000083 "A missing tooth finding in which tooth 25 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000083 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000083 "missing tooth 25 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000083 "missing tooth 25 finding"@en)
 SubClassOf(obo:OHD_0000083 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000083 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490015)))))
 
 # Class: obo:OHD_0000084 (missing tooth 26 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000084 "A missing tooth finding in which tooth 26 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000084 "A missing tooth finding in which tooth 26 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000084 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000084 "missing tooth 26 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000084 "missing tooth 26 finding"@en)
 SubClassOf(obo:OHD_0000084 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000084 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490014)))))
 
 # Class: obo:OHD_0000085 (missing tooth 27 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000085 "A missing tooth finding in which tooth 27 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000085 "A missing tooth finding in which tooth 27 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000085 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000085 "missing tooth 27 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000085 "missing tooth 27 finding"@en)
 SubClassOf(obo:OHD_0000085 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000085 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490013)))))
 
 # Class: obo:OHD_0000086 (missing tooth 28 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000086 "A missing tooth finding in which tooth 28 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000086 "A missing tooth finding in which tooth 28 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000086 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000086 "missing tooth 28 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000086 "missing tooth 28 finding"@en)
 SubClassOf(obo:OHD_0000086 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000086 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490012)))))
 
 # Class: obo:OHD_0000087 (missing tooth 29 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000087 "A missing tooth finding in which tooth 29 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000087 "A missing tooth finding in which tooth 29 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000087 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000087 "missing tooth 29 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000087 "missing tooth 29 finding"@en)
 SubClassOf(obo:OHD_0000087 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000087 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490011)))))
 
 # Class: obo:OHD_0000088 (missing tooth 30 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000088 "A missing tooth finding in which tooth 30 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000088 "A missing tooth finding in which tooth 30 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000088 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000088 "missing tooth 30 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000088 "missing tooth 30 finding"@en)
 SubClassOf(obo:OHD_0000088 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000088 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490010)))))
 
 # Class: obo:OHD_0000089 (missing tooth 31 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000089 "A missing tooth finding in which tooth 31 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000089 "A missing tooth finding in which tooth 31 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000089 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000089 "missing tooth 31 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000089 "missing tooth 31 finding"@en)
 SubClassOf(obo:OHD_0000089 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000089 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490009)))))
 
 # Class: obo:OHD_0000090 (missing tooth 32 finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000090 "A missing tooth finding in which tooth 32 is found to be missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000090 "A missing tooth finding in which tooth 32 is found to be missing."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000090 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000090 "missing tooth 32 finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000090 "missing tooth 32 finding"@en)
 SubClassOf(obo:OHD_0000090 obo:OHD_0000026)
 SubClassOf(obo:OHD_0000090 ObjectSomeValuesFrom(obo:IAO_0000136 ObjectIntersectionOf(obo:UBERON_0007774 ObjectAllValuesFrom(obo:BFO_0000051 ObjectComplementOf(obo:UBERON_8490008)))))
 
 # Class: obo:OHD_0000093 (tooth clinically present finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000093 "A dental finding that a tooth was present during a clinical exam.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000093 "A dental finding that a tooth was present during a clinical exam."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000093 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000093 <https://orcid.org/0000-0002-1604-3078>)
-AnnotationAssertion(rdfs:label obo:OHD_0000093 "tooth clinically present finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000093 "tooth clinically present finding"@en)
 SubClassOf(obo:OHD_0000093 obo:OHD_0000010)
 SubClassOf(obo:OHD_0000093 ObjectSomeValuesFrom(obo:IAO_0000136 obo:UBERON_0001091))
 
 # Class: obo:OHD_0000094 (ceramic inlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000094 "An inlay restoration procedure that uses ceramic to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000094 "An inlay restoration procedure that uses ceramic to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000094 "ceramic inlay restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000094 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000094 "ceramic inlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000094 "ceramic inlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000094 ObjectIntersectionOf(obo:OHD_0000133 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135)))
 SubClassOf(obo:OHD_0000094 obo:OHD_0000133)
 
 # Class: obo:OHD_0000095 (ceramic onlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000095 "An onlay restoration procedure that uses ceramic to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000095 "An onlay restoration procedure that uses ceramic to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000095 "ceramic onlay restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000095 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000095 "ceramic onlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000095 "ceramic onlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000095 ObjectIntersectionOf(obo:OHD_0000134 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135)))
 SubClassOf(obo:OHD_0000095 obo:OHD_0000134)
 
 # Class: obo:OHD_0000096 (resin inlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000096 "An inlay restoration procedure that uses resin to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000096 "An inlay restoration procedure that uses resin to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000096 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000096 "resin inlay restoration")
-AnnotationAssertion(rdfs:label obo:OHD_0000096 "resin inlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000096 "resin inlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000096 ObjectIntersectionOf(obo:OHD_0000133 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036)))
 SubClassOf(obo:OHD_0000096 obo:OHD_0000133)
 
 # Class: obo:OHD_0000098 (tooth to undergo inlay procedure role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000098 "A tooth to be restored role that is realized by an inlay restoration procedure")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000098 "A tooth to be restored role that is realized by an inlay restoration procedure"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000098 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000098 "tooth to undergo inlay procedure role")
+AnnotationAssertion(rdfs:label obo:OHD_0000098 "tooth to undergo inlay procedure role"@en)
 EquivalentClasses(obo:OHD_0000098 ObjectIntersectionOf(obo:OHD_0000007 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000133)))
 SubClassOf(obo:OHD_0000098 obo:OHD_0000007)
 
 # Class: obo:OHD_0000099 (tooth to undergo onlay procedure role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000099 "A tooth to be restored role that is realized by an onlay restoration procedure")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000099 "A tooth to be restored role that is realized by an onlay restoration procedure"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000099 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000099 "tooth to undergo onlay procedure role")
+AnnotationAssertion(rdfs:label obo:OHD_0000099 "tooth to undergo onlay procedure role"@en)
 EquivalentClasses(obo:OHD_0000099 ObjectIntersectionOf(obo:OHD_0000007 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OHD_0000134)))
 SubClassOf(obo:OHD_0000099 obo:OHD_0000007)
 
@@ -2770,7 +2770,7 @@ AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000100 "A label naming a type of se
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000100 "Bill Duncan 4/12/2012: From the book: \"The Universal Numbering System was first suggested by Parreidt in 1882, and officially adopted by the American Dental Association in 1975. It is accepted by third-party providers and is endorsed by the American Society of Forensic Odontology.\""@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000100 "Titus Schleyer 1/1/2014: slightly updated definition")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000100 "Book:Scheid, Rickne. Woelfel's Dental Anatomy, 8th Edition. Lippincott Williams & Wilkins, 01/2011. pp. i - ii)."@en)
-AnnotationAssertion(rdfs:label obo:OHD_0000100 "obsolete Universal tooth number")
+AnnotationAssertion(rdfs:label obo:OHD_0000100 "obsolete Universal tooth number"@en)
 AnnotationAssertion(owl:deprecated obo:OHD_0000100 "true"^^xsd:boolean)
 SubClassOf(obo:OHD_0000100 <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
@@ -3000,41 +3000,41 @@ SubClassOf(obo:OHD_0000132 <http://www.geneontology.org/formats/oboInOwl#Obsolet
 
 # Class: obo:OHD_0000133 (inlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000133 "An intracoronal restoration procedure in which dental restoration material is placed within the grooves and pits of the occlusal surface of a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000133 "An intracoronal restoration procedure in which dental restoration material is placed within the grooves and pits of the occlusal surface of a tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000133 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000133 "inlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000133 "inlay restoration procedure"@en)
 SubClassOf(obo:OHD_0000133 obo:OHD_0000006)
 
 # Class: obo:OHD_0000134 (onlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000134 "A crown restoration procedure in which the dental restoration material either replaces the cusp or overlays the cusp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000134 "A crown restoration procedure in which the dental restoration material either replaces the cusp or overlays the cusp."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000134 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000134 "onlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000134 "onlay restoration procedure"@en)
 SubClassOf(obo:OHD_0000134 obo:OHD_0000033)
 
 # Class: obo:OHD_0000138 (metallic onlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000138 "An onlay restoration procedure that uses metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000138 "An onlay restoration procedure that uses metal to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000138 "metallic onlay restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000138 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000138 "metallic onlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000138 "metallic onlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000138 ObjectIntersectionOf(obo:OHD_0000134 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000048)))
 SubClassOf(obo:OHD_0000138 obo:OHD_0000134)
 
 # Class: obo:OHD_0000139 (resin with predominantly base metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000139 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by covering all or some of a predominantly base metal substrate with resin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000139 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by covering all or some of a predominantly base metal substrate with resin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000139 "https://www.patientconnect365.com/DentalHealthTopics/Article/Crown__Resin_With_Predominately_Base_Metal__Dental_Procedure_Code_Description")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000139 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000139 "resin with predominantly base metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000139 "resin with predominantly base metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000139 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:BFO_0000051 ObjectIntersectionOf(obo:OHD_0000349 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000156))))))
 SubClassOf(obo:OHD_0000139 obo:OHD_0000033)
 
 # Class: obo:OHD_0000140 (titanium crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000140 "A crown restoration procedure that uses titanium to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000140 "A crown restoration procedure that uses titanium to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000140 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000140 "titanium crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000140 "titanium crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000140 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000136)))
 SubClassOf(obo:OHD_0000140 obo:OHD_0000033)
 
@@ -3043,15 +3043,15 @@ SubClassOf(obo:OHD_0000140 obo:OHD_0000033)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000141 "Bill Duncan 6/26/2015:
 There is not a dental restoration material of this kind. The class needs to be made obsolete.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000141 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000141 "obsolete resin with predominantly base metal dental restoration")
+AnnotationAssertion(rdfs:label obo:OHD_0000141 "obsolete resin with predominantly base metal dental restoration"@en)
 AnnotationAssertion(owl:deprecated obo:OHD_0000141 "true"^^xsd:boolean)
 SubClassOf(obo:OHD_0000141 <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: obo:OHD_0000142 (noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000142 "A crown restoration procedure that uses noble metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000142 "A crown restoration procedure that uses noble metal to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000142 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000142 "noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000142 "noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000142 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000146)))
 SubClassOf(obo:OHD_0000142 obo:OHD_0000033)
 
@@ -3060,7 +3060,7 @@ SubClassOf(obo:OHD_0000142 obo:OHD_0000033)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000143 "Bill Duncan 6/26/2015:
 There is not a dental restoration material of this kind. The class needs to be made obsolete.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000143 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000143 "obsolete porcelain fused to noble metal dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000143 "obsolete porcelain fused to noble metal dental restoration material"@en)
 AnnotationAssertion(owl:deprecated obo:OHD_0000143 "true"^^xsd:boolean)
 SubClassOf(obo:OHD_0000143 <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
@@ -3069,7 +3069,7 @@ SubClassOf(obo:OHD_0000143 <http://www.geneontology.org/formats/oboInOwl#Obsolet
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000144 "Bill Duncan 6/26/2015:
 There is not a dental restoration material of this kind. The class needs to be made obsolete.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000144 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000144 "obsolete porcelain fused to high noble metal dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000144 "obsolete porcelain fused to high noble metal dental restoration material"@en)
 AnnotationAssertion(owl:deprecated obo:OHD_0000144 "true"^^xsd:boolean)
 SubClassOf(obo:OHD_0000144 <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
@@ -3078,89 +3078,89 @@ SubClassOf(obo:OHD_0000144 <http://www.geneontology.org/formats/oboInOwl#Obsolet
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000145 "Bill Duncan 6/26/2015:
 There is not a dental restoration material of this kind. The class needs to be made obsolete.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000145 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000145 "obsolete porcelain fused to predominantly base metal dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000145 "obsolete porcelain fused to predominantly base metal dental restoration material"@en)
 AnnotationAssertion(owl:deprecated obo:OHD_0000145 "true"^^xsd:boolean)
 SubClassOf(obo:OHD_0000145 <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: obo:OHD_0000148 (resin with high noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000148 "A resin with noble metal crown restoraton procedure that uses high noble metal as a substrate.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000148 "A resin with noble metal crown restoraton procedure that uses high noble metal as a substrate."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000148 "https://www.patientconnect365.com/DentalHealthTopics/Article/Crown__Resin_With_High_Noble_Metal__Dental_Procedure_Code_Description")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000148 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000148 "resin with high noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000148 "resin with high noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000148 ObjectIntersectionOf(obo:OHD_0000166 ObjectSomeValuesFrom(obo:BFO_0000051 ObjectIntersectionOf(obo:OHD_0000349 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000147))))))
 SubClassOf(obo:OHD_0000148 obo:OHD_0000166)
 
 # Class: obo:OHD_0000149 (3/4 resin crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000149 "A 3/4 crown restoration procedure that uses resin to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000149 "A 3/4 crown restoration procedure that uses resin to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000149 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000149 "3/4 resin crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000149 "3/4 resin crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000149 ObjectIntersectionOf(obo:OHD_0000305 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036)))
 SubClassOf(obo:OHD_0000149 obo:OHD_0000305)
 
 # Class: obo:OHD_0000150 (3/4 high noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000150 "A 3/4 noble metal crown restoration procedure that uses high noble metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000150 "A 3/4 noble metal crown restoration procedure that uses high noble metal to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000150 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000150 "3/4 high noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000150 "3/4 high noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000150 ObjectIntersectionOf(obo:OHD_0000040 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000147)))
 SubClassOf(obo:OHD_0000150 obo:OHD_0000040)
 
 # Class: obo:OHD_0000151 (3/4 predominantly base metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000151 "A 3/4 crown restoration procedure that uses predominantly base metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000151 "A 3/4 crown restoration procedure that uses predominantly base metal to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000151 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000151 "3/4 predominantly base metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000151 "3/4 predominantly base metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000151 ObjectIntersectionOf(obo:OHD_0000305 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000156)))
 SubClassOf(obo:OHD_0000151 obo:OHD_0000305)
 
 # Class: obo:OHD_0000152 (3/4 ceramic crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000152 "A 3/4 crown restoration procedure that uses ceramic to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000152 "A 3/4 crown restoration procedure that uses ceramic to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000152 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000152 "3/4 ceramic crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000152 "3/4 ceramic crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000152 ObjectIntersectionOf(obo:OHD_0000305 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135)))
 SubClassOf(obo:OHD_0000152 obo:OHD_0000305)
 
 # Class: obo:OHD_0000153 (noble metal onlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000153 "A metallic onlay restoration procedure that uses noble metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000153 "A metallic onlay restoration procedure that uses noble metal to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000153 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000153 "noble metal onlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000153 "noble metal onlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000153 ObjectIntersectionOf(obo:OHD_0000138 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000146)))
 SubClassOf(obo:OHD_0000153 obo:OHD_0000138)
 
 # Class: obo:OHD_0000154 (resin crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000154 "A crown restoration procedure that uses resin to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000154 "A crown restoration procedure that uses resin to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000154 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000154 "resin crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000154 "resin crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000154 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036)))
 SubClassOf(obo:OHD_0000154 obo:OHD_0000033)
 
 # Class: obo:OHD_0000155 (ceramic crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000155 "A crown restoration procedure that uses ceramic to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000155 "A crown restoration procedure that uses ceramic to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000155 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000155 "ceramic crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000155 "ceramic crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000155 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135)))
 SubClassOf(obo:OHD_0000155 obo:OHD_0000033)
 
 # Class: obo:OHD_0000157 (high noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000157 "A noble metal crown restoration procedure that uses high noble metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000157 "A noble metal crown restoration procedure that uses high noble metal to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000157 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000157 "high noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000157 "high noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000157 ObjectIntersectionOf(obo:OHD_0000142 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000147)))
 SubClassOf(obo:OHD_0000157 obo:OHD_0000142)
 
 # Class: obo:OHD_0000158 (porcelain fused to high noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000158 "A procelain fused to nobal metal crown restoration procedure that uses high noble metal as a substrate.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000158 "A procelain fused to nobal metal crown restoration procedure that uses high noble metal as a substrate."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000158 "https://www.patientconnect365.com/DentalHealthTopics/Article/Crown__Porcelain_Fused_To_High_Noble_Metal__Dental_Procedure_Code_Description")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000158 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000158 "porcelain fused to high noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000158 "porcelain fused to high noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000158 ObjectIntersectionOf(obo:OHD_0000160 ObjectSomeValuesFrom(obo:BFO_0000051 ObjectIntersectionOf(obo:OHD_0000306 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000147))))))
 SubClassOf(obo:OHD_0000158 obo:OHD_0000160)
 
@@ -3175,19 +3175,19 @@ SubClassOf(obo:OHD_0000159 obo:OHD_0000153)
 
 # Class: obo:OHD_0000160 (porcelain fused to noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000160 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by fusing porcelain to a substrate composed of noble metal.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000160 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by fusing porcelain to a substrate composed of noble metal."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000160 "https://www.patientconnect365.com/DentalHealthTopics/Article/Crown__Porcelain_Fused_To_Noble_Metal__Dental_Procedure_Code_Description")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000160 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000160 "porcelain fused to noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000160 "porcelain fused to noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000160 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:BFO_0000051 ObjectIntersectionOf(obo:OHD_0000306 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000146))))))
 SubClassOf(obo:OHD_0000160 obo:OHD_0000033)
 
 # Class: obo:OHD_0000161 (porcelain fused to predominantly base metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000161 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by fusing porcelain to a substrate composed of predominatly base metal.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000161 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by fusing porcelain to a substrate composed of predominatly base metal."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000161 "https://www.patientconnect365.com/DentalHealthTopics/Article/Crown__Porcelain_Fused_To_Predominately_Base_Metal__Dental_Procedure_Code_Description")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000161 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000161 "porcelain fused to predominantly base metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000161 "porcelain fused to predominantly base metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000161 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:BFO_0000051 ObjectIntersectionOf(obo:OHD_0000306 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000135) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000156))))))
 SubClassOf(obo:OHD_0000161 obo:OHD_0000033)
 
@@ -3196,25 +3196,25 @@ SubClassOf(obo:OHD_0000161 obo:OHD_0000033)
 AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000162 "A crown restoration material that uses predominantly base metal to restore the crown."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000162 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000162 <https://orcid.org/0009-0002-7282-0836>)
-AnnotationAssertion(rdfs:label obo:OHD_0000162 "predominantly base metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000162 "predominantly base metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000162 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000156)))
 SubClassOf(obo:OHD_0000162 obo:OHD_0000033)
 
 # Class: obo:OHD_0000163 (stainless steel crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000163 "A crown restoration procedure that uses stainless steel to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000163 "A crown restoration procedure that uses stainless steel to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000163 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000163 "stainless steel crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000163 "stainless steel crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000163 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000137)))
 SubClassOf(obo:OHD_0000163 obo:OHD_0000033)
 
 # Class: obo:OHD_0000164 (stainless steel with resin window crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000164 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by cutting a window into a stainless steel prosthetic crown and filling the window with resin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000164 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by cutting a window into a stainless steel prosthetic crown and filling the window with resin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000164 "http://www.dentalcare.com/en-US/dental-education/continuing-education/ce379/ce379.aspx?ModuleName=coursecontent&PartID=3&SectionID=-1")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000164 "https://www.patientconnect365.com/DentalHealthTopics/Article/Crown__Prefabricated_Stainless_Steel_with_Resin__Dental_Procedure_Code_Description")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000164 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000164 "stainless steel with resin window crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000164 "stainless steel with resin window crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000164 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:BFO_0000051 ObjectIntersectionOf(obo:OHD_0000349 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000137))))))
 SubClassOf(obo:OHD_0000164 obo:OHD_0000033)
 
@@ -3224,15 +3224,15 @@ AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000165 "A dental health care provid
 .")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000165 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 55.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000165 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000165 "dental assistant role")
+AnnotationAssertion(rdfs:label obo:OHD_0000165 "dental assistant role"@en)
 SubClassOf(obo:OHD_0000165 obo:OHD_0000052)
 
 # Class: obo:OHD_0000166 (resin with noble metal crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000166 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by covering all or some of a noble metal substrate with resin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000166 "A crown restoration procedure in which the artificial crown used to restore the tooth is formed by covering all or some of a noble metal substrate with resin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000166 "https://www.patientconnect365.com/DentalHealthTopics/Article/Crown__Resin_With_Noble_Metal__Dental_Procedure_Code_Description")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000166 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000166 "resin with noble metal crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000166 "resin with noble metal crown restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000166 ObjectIntersectionOf(obo:OHD_0000033 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000349) ObjectSomeValuesFrom(obo:BFO_0000051 ObjectIntersectionOf(obo:OHD_0000349 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000146))))))
 SubClassOf(obo:OHD_0000166 obo:OHD_0000033)
 
@@ -3247,24 +3247,24 @@ SubClassOf(obo:OHD_0000167 obo:OHD_0000022)
 
 # Class: obo:OHD_0000168 (unerupted tooth finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000168 "A dental finding that a tooth has not errupted.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000168 "A dental finding that a tooth has not errupted."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000168 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000168 <https://orcid.org/0000-0002-1604-3078>)
-AnnotationAssertion(rdfs:label obo:OHD_0000168 "unerupted tooth finding")
+AnnotationAssertion(rdfs:label obo:OHD_0000168 "unerupted tooth finding"@en)
 SubClassOf(obo:OHD_0000168 obo:OHD_0000010)
 
 # Class: obo:OHD_0000169 (resin onlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000169 "An onlay restoration procedure that uses resin to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000169 "An onlay restoration procedure that uses resin to restore the tooth."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000169 "resin onlay restoration")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000169 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000169 "resin onlay restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000169 "resin onlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000169 ObjectIntersectionOf(obo:OHD_0000134 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000036)))
 SubClassOf(obo:OHD_0000169 obo:OHD_0000134)
 
 # Class: obo:OHD_0000170 (dental therapist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000170 "A dentist role that inheres in a person a dentist who practices as part of the dental team to provide educational, clinical and therapeutic patient services; and can provide basic preventive and restorative treatment to children and adults, and extractions of primary (baby) teeth under the supervision of a dentist.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000170 "A dentist role that inheres in a person a dentist who practices as part of the dental team to provide educational, clinical and therapeutic patient services; and can provide basic preventive and restorative treatment to children and adults, and extractions of primary (baby) teeth under the supervision of a dentist."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000170 "http://dentistry.umn.edu/programs-admissions/dental-therapy/index.htm")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000170 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000170 "dental therapist role"@en)
@@ -3272,28 +3272,28 @@ SubClassOf(obo:OHD_0000170 obo:OHD_0000052)
 
 # Class: obo:OHD_0000171 (endodontist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000171 "A dentist role that inheres in a person who specializes in performing endodontic procedures.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000171 "A dentist role that inheres in a person who specializes in performing endodontic procedures."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000171 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000171 "endodontist role"@en)
 SubClassOf(obo:OHD_0000171 obo:OHD_0000017)
 
 # Class: obo:OHD_0000172 (oral surgeon role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000172 "A dentist role that inheres in a person who specializes in performing oral surgery.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000172 "A dentist role that inheres in a person who specializes in performing oral surgery."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000172 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000172 "oral surgeon role"@en)
 SubClassOf(obo:OHD_0000172 obo:OHD_0000017)
 
 # Class: obo:OHD_0000173 (orofacial pain dentist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000173 "A dentist role that inheres in a person who has received specialized training in treating disorders that cause orofacial pain, such as TMJ disorder (TMD).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000173 "A dentist role that inheres in a person who has received specialized training in treating disorders that cause orofacial pain, such as TMJ disorder (TMD)."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000173 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000173 "orofacial pain dentist role"@en)
 SubClassOf(obo:OHD_0000173 obo:OHD_0000017)
 
 # Class: obo:OHD_0000174 (orthodontist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000174 "A dentist role that inheres in a person who specializes in the prevention and correction of irregular teeth, as by means of braces.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000174 "A dentist role that inheres in a person who specializes in the prevention and correction of irregular teeth, as by means of braces."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000174 "http://dictionary.reference.com/browse/orthodontist")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000174 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000174 "orthodontist role"@en)
@@ -3301,7 +3301,7 @@ SubClassOf(obo:OHD_0000174 obo:OHD_0000017)
 
 # Class: obo:OHD_0000175 (pediatric dentist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000175 "A dentist role that inheres in a person who specializes in children's oral health.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000175 "A dentist role that inheres in a person who specializes in children's oral health."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000175 "http://www.aapd.org")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000175 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000175 "pediatric dentist role"@en)
@@ -3309,7 +3309,7 @@ SubClassOf(obo:OHD_0000175 obo:OHD_0000017)
 
 # Class: obo:OHD_0000176 (periodontist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000176 "A dentist role that inheres in a person who specializes in the prevention, diagnosis, and treatment of periodontal disease, oral inflammation, and in the placement of dental implants.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000176 "A dentist role that inheres in a person who specializes in the prevention, diagnosis, and treatment of periodontal disease, oral inflammation, and in the placement of dental implants."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000176 "https://www.perio.org/consumer/periodontist2.htm")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000176 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000176 "periodontist role"@en)
@@ -3317,7 +3317,7 @@ SubClassOf(obo:OHD_0000176 obo:OHD_0000017)
 
 # Class: obo:OHD_0000177 (prosthodontist role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000177 "A dentist role that inheres in a person who specializes in the aesthetic (cosmetic) restoration and replacement of teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000177 "A dentist role that inheres in a person who specializes in the aesthetic (cosmetic) restoration and replacement of teeth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000177 "https://en.wikipedia.org/wiki/Prosthodontics")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000177 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000177 "prosthodontist role"@en)
@@ -3325,7 +3325,7 @@ SubClassOf(obo:OHD_0000177 obo:OHD_0000017)
 
 # Class: obo:OHD_0000178 (registered nurse role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000178 "A health care provider role that inheres in a person who specializes in the protection, promotion, and optimization of health and abilities, prevention of illness and injury, alleviation of suffering through the diagnosis and treatment of human response, and advocacy in the care of individuals, families, communities, and populations.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000178 "A health care provider role that inheres in a person who specializes in the protection, promotion, and optimization of health and abilities, prevention of illness and injury, alleviation of suffering through the diagnosis and treatment of human response, and advocacy in the care of individuals, families, communities, and populations."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000178 "http://www.nursingworld.org/EspeciallyForYou/What-is-Nursing")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000178 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000178 "registered nurse role"@en)
@@ -3333,7 +3333,7 @@ SubClassOf(obo:OHD_0000178 obo:OHD_0000212)
 
 # Class: obo:OHD_0000179 (healthcare provider)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000179 "A Homo sapiens that bears a health care provider role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000179 "A Homo sapiens that bears a health care provider role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000179 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000179 "healthcare provider"@en)
 EquivalentClasses(obo:OHD_0000179 ObjectIntersectionOf(obo:NCBITaxon_9606 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000212)))
@@ -3341,7 +3341,7 @@ SubClassOf(obo:OHD_0000179 obo:NCBITaxon_9606)
 
 # Class: obo:OHD_0000180 (registered nurse)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000180 "A health care provider that bears a registered nurse role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000180 "A health care provider that bears a registered nurse role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000180 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000180 "registered nurse"@en)
 EquivalentClasses(obo:OHD_0000180 ObjectIntersectionOf(obo:OHD_0000179 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000178)))
@@ -3349,7 +3349,7 @@ SubClassOf(obo:OHD_0000180 obo:OHD_0000179)
 
 # Class: obo:OHD_0000181 (dental therapist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000181 "A dental health care provider that bears a dental therapist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000181 "A dental health care provider that bears a dental therapist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000181 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000181 "dental therapist"@en)
 EquivalentClasses(obo:OHD_0000181 ObjectIntersectionOf(obo:OHD_0000051 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000170)))
@@ -3357,7 +3357,7 @@ SubClassOf(obo:OHD_0000181 obo:OHD_0000051)
 
 # Class: obo:OHD_0000182 (endodontist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000182 "A dentist that bears a endodontist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000182 "A dentist that bears a endodontist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000182 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000182 "endodontist"@en)
 EquivalentClasses(obo:OHD_0000182 ObjectIntersectionOf(obo:OHD_0000018 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000171)))
@@ -3365,7 +3365,7 @@ SubClassOf(obo:OHD_0000182 obo:OHD_0000018)
 
 # Class: obo:OHD_0000183 (oral surgeon)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000183 "A dentist that bears an oral surgeon role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000183 "A dentist that bears an oral surgeon role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000183 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000183 "oral surgeon"@en)
 EquivalentClasses(obo:OHD_0000183 ObjectIntersectionOf(obo:OHD_0000018 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000172)))
@@ -3373,7 +3373,7 @@ SubClassOf(obo:OHD_0000183 obo:OHD_0000018)
 
 # Class: obo:OHD_0000184 (orofacial pain dentist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000184 "A dentist that bears an orofacial pain dentist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000184 "A dentist that bears an orofacial pain dentist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000184 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000184 "orofacial pain dentist"@en)
 EquivalentClasses(obo:OHD_0000184 ObjectIntersectionOf(obo:OHD_0000018 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000173)))
@@ -3381,7 +3381,7 @@ SubClassOf(obo:OHD_0000184 obo:OHD_0000018)
 
 # Class: obo:OHD_0000185 (orthodontist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000185 "A dentist that bears an orthodontist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000185 "A dentist that bears an orthodontist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000185 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000185 "orthodontist"@en)
 EquivalentClasses(obo:OHD_0000185 ObjectIntersectionOf(obo:OHD_0000018 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000174)))
@@ -3389,7 +3389,7 @@ SubClassOf(obo:OHD_0000185 obo:OHD_0000018)
 
 # Class: obo:OHD_0000186 (pediatric dentist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000186 "A dentist that bears a pediatric dentist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000186 "A dentist that bears a pediatric dentist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000186 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000186 "pediatric dentist"@en)
 EquivalentClasses(obo:OHD_0000186 ObjectIntersectionOf(obo:OHD_0000018 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000175)))
@@ -3397,7 +3397,7 @@ SubClassOf(obo:OHD_0000186 obo:OHD_0000018)
 
 # Class: obo:OHD_0000187 (periodontist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000187 "A dentist that bears a periodontist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000187 "A dentist that bears a periodontist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000187 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000187 "periodontist"@en)
 EquivalentClasses(obo:OHD_0000187 ObjectIntersectionOf(obo:OHD_0000018 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000176)))
@@ -3408,13 +3408,13 @@ SubClassOf(obo:OHD_0000187 obo:OHD_0000018)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000188 "Bill Duncan 6/26/2015:
 There is not a dental restoration material of this kind. The class needs to be made obsolete.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000188 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000188 "obsolete stainless steel with resin window dental restoration material")
+AnnotationAssertion(rdfs:label obo:OHD_0000188 "obsolete stainless steel with resin window dental restoration material"@en)
 AnnotationAssertion(owl:deprecated obo:OHD_0000188 "true"^^xsd:boolean)
 SubClassOf(obo:OHD_0000188 <http://www.geneontology.org/formats/oboInOwl#ObsoleteClass>)
 
 # Class: obo:OHD_0000189 (restored tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000189 "A tooth that has been restored by using dental restoration material to replace decayed or missing parts of the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000189 "A tooth that has been restored by using dental restoration material to replace decayed or missing parts of the tooth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000189 "Bill Duncan 12/29/2017:
 A restored tooth typically results when a tooth with some type of pathological defect is restored.")
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000189 "Titus Schleyer 1/1/2014: updated definition")
@@ -3426,7 +3426,7 @@ SubClassOf(obo:OHD_0000189 obo:UBERON_0001091)
 
 # Class: obo:OHD_0000190 (dental patient role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000190 "A patient role that is realized by the process of being under the care of a dental health care provider.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000190 "A patient role that is realized by the process of being under the care of a dental health care provider."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000190 "Alan Ruttenberg")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000190 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000190 "dental patient role"@en)
@@ -3454,7 +3454,7 @@ SubClassOf(obo:OHD_0000192 obo:OHD_0000167)
 
 # Class: obo:OHD_0000193 (predominantly base metal onlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000193 "An onlay restoration procedure that uses predominantly base metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000193 "An onlay restoration procedure that uses predominantly base metal to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000193 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000193 "predominantly base metal onlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000193 ObjectIntersectionOf(obo:OHD_0000134 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000156)))
@@ -3462,7 +3462,7 @@ SubClassOf(obo:OHD_0000193 obo:OHD_0000134)
 
 # Class: obo:OHD_0000194 (predominantly base metal inlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000194 "An inlay restoration procedure that uses predominantly base metal to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000194 "An inlay restoration procedure that uses predominantly base metal to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000194 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000194 "predominantly base metal inlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000194 ObjectIntersectionOf(obo:OHD_0000133 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038) ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000156)))
@@ -3470,7 +3470,7 @@ SubClassOf(obo:OHD_0000194 obo:OHD_0000133)
 
 # Class: obo:OHD_0000195 (titanium onlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000195 "A metallic onlay restoration procedure that uses titanium to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000195 "A metallic onlay restoration procedure that uses titanium to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000195 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000195 "titanium onlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000195 ObjectIntersectionOf(obo:OHD_0000138 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000136)))
@@ -3478,7 +3478,7 @@ SubClassOf(obo:OHD_0000195 obo:OHD_0000138)
 
 # Class: obo:OHD_0000196 (titanium inlay restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000196 "A metallic inlay restoration procedure that uses titanium to restore the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000196 "A metallic inlay restoration procedure that uses titanium to restore the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000196 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000196 "titanium inlay restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000196 ObjectIntersectionOf(obo:OHD_0000022 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000136)))
@@ -3486,7 +3486,7 @@ SubClassOf(obo:OHD_0000196 obo:OHD_0000022)
 
 # Class: obo:OHD_0000197 (oral evaluation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000197 "A visual and tactile examination in which the clinician evaluates the status of the patient's oral cavity and related areas. An oral evaluation is performed as part of a dental exam. The examination may also include the results of tests, such as radiographs, pulp vitality, etc.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000197 "A visual and tactile examination in which the clinician evaluates the status of the patient's oral cavity and related areas. An oral evaluation is performed as part of a dental exam. The examination may also include the results of tests, such as radiographs, pulp vitality, etc."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000197 "This class was created in order to associate oral evaluations with dental findings that came about as the result of a dental exam. The data source I am working with has records that show multiple oral evalutions were performed on the same day. For example, the data source may have records that show a periodic oral evaluation, comprehensive oral evaluation, and comprehensive periodontal evaluation are performed on the same day. However, the finding(s) for these evaluations is/are stored in a separate table with only the patient id and date to associate the finding with the exam. There is no information to link the finding to a particular evaluation. 
 
 As a work around (i.e., hack!), I've made oral evaluations be part of the dental examination. There is a case to be made that oral evaluations should be a subclass of dental exam, but, such a representation, would make representing the finding information (associated with a particular oral evaluation) difficult.")
@@ -3494,18 +3494,18 @@ AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000197 "Titus Schleyer 1/14/2014: u
 
 Also, regarding Bill's comment on the fact that multiple examinations can occur on the same day (e.g.  periodic oral evaluation, comprehensive oral evaluation and comprehensive periodontal evaluation): From a billing and clinical perspective,  these are separate. For instance, a comprehensive oral evaluation has a larger scope than a periodic oral evaluation, while a  comprehensive periodontal evaluation is focused primarily on gums and supporting tissues.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000197 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000197 "oral evaluation")
+AnnotationAssertion(rdfs:label obo:OHD_0000197 "oral evaluation"@en)
 SubClassOf(obo:OHD_0000197 obo:OGMS_0000057)
 SubClassOf(obo:OHD_0000197 ObjectSomeValuesFrom(obo:BFO_0000050 obo:OHD_0000019))
 SubClassOf(obo:OHD_0000197 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0000052))
 
 # Class: obo:OHD_0000198 (periodic oral evaluation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000198 "An oral evaluation performed on a patient of record (at an interval specified by the dentist) to determine any changes in the patients dental and medical health status since a previous evaluation. It includes an oral cancer evaluation and periodontal screening where indicated, and may require interpretation of information acquired through additional diagnostic procedures.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000198 "An oral evaluation performed on a patient of record (at an interval specified by the dentist) to determine any changes in the patients dental and medical health status since a previous evaluation. It includes an oral cancer evaluation and periodontal screening where indicated, and may require interpretation of information acquired through additional diagnostic procedures."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000198 "Titus Schleyer 1/1/2014: updated definition")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000198 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000198 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000198 "periodic oral evaluation")
+AnnotationAssertion(rdfs:label obo:OHD_0000198 "periodic oral evaluation"@en)
 SubClassOf(obo:OHD_0000198 obo:OHD_0000197)
 SubClassOf(obo:OHD_0000198 ObjectSomeValuesFrom(obo:BFO_0000051 ObjectUnionOf(obo:OHD_0000025 obo:OHD_0000032)))
 
@@ -3519,7 +3519,7 @@ SubClassOf(obo:OHD_0000199 obo:OHD_0000154)
 
 # Class: obo:OHD_0000200 (no oral health issues reported)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000200 "A dental finding in which there were no oral health issues were reported.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000200 "A dental finding in which there were no oral health issues were reported."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000200 "The intent of the class is to represent those case in which a dental exam is performed on patient, no finding is reported for the exam.  This could mean that the patients mouth is healthy; the patient had an issue but the examiner failed to report it; or (perhaps) that the patient has some oral health issue, but there are no new issues to report.
 
 The label of the class may need to be changed.")
@@ -3527,15 +3527,15 @@ AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000200 "Titus Schleyer 1/14/2014: a
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000200 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000200 "PERSON: Bill Duncan")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000200 "a role that inheres in a person who licensed to provide health care")
-AnnotationAssertion(rdfs:label obo:OHD_0000200 "no oral health issues reported")
+AnnotationAssertion(rdfs:label obo:OHD_0000200 "no oral health issues reported"@en)
 SubClassOf(obo:OHD_0000200 obo:OHD_0000010)
 
 # Class: obo:OHD_0000201 (limited oral evaluation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000201 "An oral evaluation limited to a specific oral health problem or complaint. This may require interpretation of information acquired through additional diagnostic procedures. Typically, patients receiving this type of evaluation present with a specific problem and/or dental emergencies, trauma, acute infections, etc.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000201 "An oral evaluation limited to a specific oral health problem or complaint. This may require interpretation of information acquired through additional diagnostic procedures. Typically, patients receiving this type of evaluation present with a specific problem and/or dental emergencies, trauma, acute infections, etc."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000201 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000201 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000201 "limited oral evaluation")
+AnnotationAssertion(rdfs:label obo:OHD_0000201 "limited oral evaluation"@en)
 SubClassOf(obo:OHD_0000201 obo:OHD_0000197)
 SubClassOf(obo:OHD_0000201 ObjectSomeValuesFrom(obo:BFO_0000051 ObjectUnionOf(obo:OHD_0000025 obo:OHD_0000032)))
 
@@ -3547,7 +3547,7 @@ This includes an evaluation for oral cancer where indicated, the evaluation and 
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000202 "Titus Schleyer 1/1/2014: checked definition, looks okay")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000202 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000202 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000202 "comprehensive oral evaluation")
+AnnotationAssertion(rdfs:label obo:OHD_0000202 "comprehensive oral evaluation"@en)
 SubClassOf(obo:OHD_0000202 obo:OHD_0000197)
 SubClassOf(obo:OHD_0000202 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000025))
 SubClassOf(obo:OHD_0000202 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000204))
@@ -3555,17 +3555,17 @@ SubClassOf(obo:OHD_0000202 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000205)
 
 # Class: obo:OHD_0000203 (comprehensive periodontal evaluation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000203 "An oral evaluation performed on patients showing signs or symptoms of periodontal disease and for patients with risk factors for such disease, such as smoking or diabetes.  It includes evaluation of periodontal conditions, probing and charting, evaluation and recording of the patients dental and medical history and general health assessment.  It may include the evaluation and recording of dental caries, missing or unerupted teeth, restorations and occlusal relationships.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000203 "An oral evaluation performed on patients showing signs or symptoms of periodontal disease and for patients with risk factors for such disease, such as smoking or diabetes.  It includes evaluation of periodontal conditions, probing and charting, evaluation and recording of the patients dental and medical history and general health assessment.  It may include the evaluation and recording of dental caries, missing or unerupted teeth, restorations and occlusal relationships."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000203 "Titus Schleyer 1/1/2014: slightly updated definition")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000203 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000203 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000203 "comprehensive periodontal evaluation")
+AnnotationAssertion(rdfs:label obo:OHD_0000203 "comprehensive periodontal evaluation"@en)
 SubClassOf(obo:OHD_0000203 obo:OHD_0000197)
 SubClassOf(obo:OHD_0000203 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000204))
 
 # Class: obo:OHD_0000204 (intraoral soft tissue exam)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000204 "A physical examination of the soft tissue of the mouth, including the lips, mucosa, hard and soft palate, tongue, and floor of mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000204 "A physical examination of the soft tissue of the mouth, including the lips, mucosa, hard and soft palate, tongue, and floor of mouth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000204 "technically I don't need to include giniva since it is mucosa, but felt like it in the interest of avoiding questions")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000204 "Alan Ruttenberg")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000204 "http://www.dentistry.utoronto.ca/dpes/diagnostic/patients/extraoral-and-intraoral-soft-tissue-examination-patient")
@@ -3576,7 +3576,7 @@ SubClassOf(obo:OHD_0000204 ObjectSomeValuesFrom(obo:OBI_0000293 ObjectUnionOf(ob
 
 # Class: obo:OHD_0000205 (extraoral soft tissue exam)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000205 "A physical examination of the soft tissue of the head and neck with attention to the temporomandibular joint area.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000205 "A physical examination of the soft tissue of the head and neck with attention to the temporomandibular joint area."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000205 "Alan Ruttenberg")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000205 "http://www.dentistry.utoronto.ca/dpes/diagnostic/patients/extraoral-and-intraoral-soft-tissue-examination-patient")
 AnnotationAssertion(rdfs:label obo:OHD_0000205 "extraoral soft tissue exam"@en)
@@ -3586,7 +3586,7 @@ SubClassOf(obo:OHD_0000205 ObjectSomeValuesFrom(obo:OBI_0000293 ObjectUnionOf(ob
 
 # Class: obo:OHD_0000206 (functional tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000206 "A natural, modified or prosthetic tooth")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000206 "A natural, modified or prosthetic tooth"@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000206 "Alan Ruttenberg")
 AnnotationAssertion(rdfs:label obo:OHD_0000206 "functional tooth"@en)
 EquivalentClasses(obo:OHD_0000206 ObjectUnionOf(obo:OHD_0000189 obo:OHD_0000302 obo:UBERON_0001091))
@@ -3594,7 +3594,7 @@ SubClassOf(obo:OHD_0000206 obo:OBI_0000047)
 
 # Class: obo:OHD_0000207 (tooth surface to be restored role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000207 "A target of material addition role that inheres in some part of a tooth and is realized in a process where dental material forms a new surface")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000207 "A target of material addition role that inheres in some part of a tooth and is realized in a process where dental material forms a new surface"@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000207 "Can't say the role inheres in a surface as the problem may be that the  particular surface isn't present before the restoration.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000207 "Alan Ruttenberg")
 AnnotationAssertion(rdfs:label obo:OHD_0000207 "tooth surface to be restored role"@en)
@@ -3604,7 +3604,7 @@ SubClassOf(obo:OHD_0000207 ObjectSomeValuesFrom(obo:BFO_0000054 ObjectIntersecti
 
 # Class: obo:OHD_0000208 (restored tooth surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000208 "A processed material that is part of a restored tooth and forms the part of a restored tooth where a the surface enamel of the restored tooth used to be.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000208 "A processed material that is part of a restored tooth and forms the part of a restored tooth where a the surface enamel of the restored tooth used to be."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000208 "Alan Ruttenberg")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000208 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000208 "restored tooth surface"@en)
@@ -3622,7 +3622,7 @@ SubClassOf(obo:OHD_0000210 obo:OHD_0000051)
 
 # Class: obo:OHD_0000211 (dental practice facility)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000211 "A physical structure, such as a building, in which dental care is provided by licensed providers.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000211 "A physical structure, such as a building, in which dental care is provided by licensed providers."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000211 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000211 "2022-12-06T01:28:31Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000211 "dental practice facility"@en)
@@ -3630,16 +3630,16 @@ SubClassOf(obo:OHD_0000211 obo:BFO_0000004)
 
 # Class: obo:OHD_0000212 (healthcare provider role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000212 "A role that inheres in a person who is licensed to provide health care.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000212 "A role that inheres in a person who is licensed to provide health care."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000212 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000212 "healthcare provider role")
+AnnotationAssertion(rdfs:label obo:OHD_0000212 "healthcare provider role"@en)
 SubClassOf(obo:OHD_0000212 obo:BFO_0000023)
 SubClassOf(obo:OHD_0000212 ObjectSomeValuesFrom(obo:BFO_0000052 obo:NCBITaxon_9606))
 SubClassOf(obo:OHD_0000212 ObjectSomeValuesFrom(obo:BFO_0000054 obo:OGMS_0000096))
 
 # Class: obo:OHD_0000213 (prosthodontist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000213 "A dentist that bears a prosthodontist role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000213 "A dentist that bears a prosthodontist role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000213 "Bill Duncan")
 AnnotationAssertion(rdfs:label obo:OHD_0000213 "prosthodontist"@en)
 EquivalentClasses(obo:OHD_0000213 ObjectIntersectionOf(obo:OHD_0000018 ObjectSomeValuesFrom(obo:RO_0000087 obo:OHD_0000177)))
@@ -3647,7 +3647,7 @@ SubClassOf(obo:OHD_0000213 obo:OHD_0000018)
 
 # Class: obo:OHD_0000214 (healthcare organization employee role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000214 "A role borne by a person who is employed by health care organization.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000214 "A role borne by a person who is employed by health care organization."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000214 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000214 "2022-12-06T01:30:55Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000214 "healthcare organization employee role"@en)
@@ -3655,7 +3655,7 @@ SubClassOf(obo:OHD_0000214 obo:BFO_0000023)
 
 # Class: obo:OHD_0000215 (healthcare office staff role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000215 "A healthcare organization employee role born by a person who works as office in a healthcare organization.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000215 "A healthcare organization employee role born by a person who works as office in a healthcare organization."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000215 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000215 "2022-12-06T01:32:39Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000215 "healthcare office staff role"@en)
@@ -3663,7 +3663,7 @@ SubClassOf(obo:OHD_0000215 obo:OHD_0000214)
 
 # Class: obo:OHD_0000220 (restored tooth surface finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000220 "A dental finding that one or more surfaces of a tooth have been restored.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000220 "A dental finding that one or more surfaces of a tooth have been restored."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000220 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000220 "2022-12-06T01:39:35Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000220 "restored tooth surface finding"@en)
@@ -3672,7 +3672,7 @@ SubClassOf(obo:OHD_0000220 obo:OHD_0000010)
 
 # Class: obo:OHD_0000221 (dental procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000221 "A dental finding that a dental procedure has been performed on a patient's mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000221 "A dental finding that a dental procedure has been performed on a patient's mouth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000221 "Bill Duncan 12/27/2016:
 
 This finding can indicate that a procedure was performed even when the output is not observable. For example, by looking a dental record, a provider may find that the last time a patient's teeth were cleaned was two years ago.")
@@ -3683,7 +3683,7 @@ SubClassOf(obo:OHD_0000221 obo:OHD_0000010)
 
 # Class: obo:OHD_0000222 (restored buccal surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000222 "A restored tooth surface that forms the buccal surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000222 "A restored tooth surface that forms the buccal surface of a restored tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000222 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000222 "2022-12-06T02:41:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000222 "restored buccal surface"@en)
@@ -3691,7 +3691,7 @@ SubClassOf(obo:OHD_0000222 obo:OHD_0000208)
 
 # Class: obo:OHD_0000223 (restored distal surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000223 "A restored tooth surface that forms the distal surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000223 "A restored tooth surface that forms the distal surface of a restored tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000223 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000223 "2022-12-06T02:41:41Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000223 "restored distal surface"@en)
@@ -3699,7 +3699,7 @@ SubClassOf(obo:OHD_0000223 obo:OHD_0000208)
 
 # Class: obo:OHD_0000224 (restored incisal surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000224 "A restored tooth surface that forms the incisal surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000224 "A restored tooth surface that forms the incisal surface of a restored tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000224 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000224 "2022-12-06T02:44:18Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000224 "restored incisal surface"@en)
@@ -3707,7 +3707,7 @@ SubClassOf(obo:OHD_0000224 obo:OHD_0000208)
 
 # Class: obo:OHD_0000225 (restored labial surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000225 "A restored tooth surface that forms the labial surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000225 "A restored tooth surface that forms the labial surface of a restored tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000225 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000225 "2022-12-06T02:47:52Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000225 "restored labial surface"@en)
@@ -3715,7 +3715,7 @@ SubClassOf(obo:OHD_0000225 obo:OHD_0000208)
 
 # Class: obo:OHD_0000226 (restored lingual surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000226 "A restored tooth surface that forms the lingual surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000226 "A restored tooth surface that forms the lingual surface of a restored tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000226 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000226 "2022-12-06T02:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000226 "restored lingual surface"@en)
@@ -3723,7 +3723,7 @@ SubClassOf(obo:OHD_0000226 obo:OHD_0000208)
 
 # Class: obo:OHD_0000227 (restored mesial surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000227 "A restored tooth surface that forms the mesial surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000227 "A restored tooth surface that forms the mesial surface of a restored tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000227 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000227 "2022-12-06T02:50:33Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000227 "restored mesial surface"@en)
@@ -3731,7 +3731,7 @@ SubClassOf(obo:OHD_0000227 obo:OHD_0000208)
 
 # Class: obo:OHD_0000228 (restored occlusal surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000228 "A restored tooth surface that forms the occlusal surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000228 "A restored tooth surface that forms the occlusal surface of a restored tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000228 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000228 "2022-12-06T02:51:08Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000228 "restored occlusal surface"@en)
@@ -3739,7 +3739,7 @@ SubClassOf(obo:OHD_0000228 obo:OHD_0000208)
 
 # Class: obo:OHD_0000229 (hemisection procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000229 "A surgical endodontic procedure involving a multi-root tooth in which the decayed root and its related coronal portion are removed to the furcation (area of bone loss).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000229 "A surgical endodontic procedure involving a multi-root tooth in which the decayed root and its related coronal portion are removed to the furcation (area of bone loss)."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000229 "Bill Duncan 12/29/2016:
 Typically the removal of root/crown/bone is followed by the placement of an indirect restoration.")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000229 "http://medical-dictionary.thefreedictionary.com/hemisection")
@@ -3750,7 +3750,7 @@ SubClassOf(obo:OHD_0000229 obo:OHD_0000243)
 
 # Class: obo:OHD_0000230 (endodontic treatment procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000230 "A restored tooth in which the tooth's pulp is removed and replaced by dental restoration material.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000230 "A restored tooth in which the tooth's pulp is removed and replaced by dental restoration material."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000230 "root canal treatment procedure")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000230 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000230 "2022-12-06T02:21:35Z"^^xsd:dateTime)
@@ -3760,7 +3760,7 @@ SubClassOf(obo:OHD_0000230 obo:OHD_0000242)
 # Class: obo:OHD_0000231 (surgically modified tooth)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000231 "A tooth in which inflamed pulp has been removed by a pulp debridement procedure.")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000231 "A tooth that has been modified in some way as the result of some surgical dental procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000231 "A tooth that has been modified in some way as the result of some surgical dental procedure."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000231 "Bill Duncan 12/29/2016:
 The intent of this class is to represent teeth that have undergone some kind of surgical procedure, but which are not restored in the sense of having dental restoration material placed in them; e.g, a pulp debridement procedure.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000231 <https://orcid.org/0000-0001-9625-1899>)
@@ -3771,7 +3771,7 @@ SubClassOf(obo:OHD_0000231 obo:UBERON_0001091)
 
 # Class: obo:OHD_0000232 (pulpal debridement procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000232 "A surgical endodontic procedure in which infected pulp is removed from a tooth in order to give the remaining pulp room to swell.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000232 "A surgical endodontic procedure in which infected pulp is removed from a tooth in order to give the remaining pulp room to swell."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000232 "Bill Duncan 12/29/2016:
 This procedure relieves some of the pain, allowing a root canal patient to wait longer before having the full procedure performed.")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000232 "http://www.ehow.com/facts_7478434_pulpal-debridement.html")
@@ -3782,7 +3782,7 @@ SubClassOf(obo:OHD_0000232 obo:OHD_0000243)
 
 # Class: obo:OHD_0000233 (extracted tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000233 "A tooth that has been surgically extracted from a patient's mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000233 "A tooth that has been surgically extracted from a patient's mouth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000233 "Bill Duncan 12/29/2016:
 This class represents those teeth which are extracted from a patient. After all, an extracted tooth is still a tooth. It just isn't part of the patient anymore.
 
@@ -3795,7 +3795,7 @@ SubClassOf(obo:OHD_0000233 obo:UBERON_0001091)
 
 # Class: obo:OHD_0000235 (restored facial surface)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000235 "A restored tooth surface that forms the lip-facing or cheek-facing surface of a restored tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000235 "A restored tooth surface that forms the lip-facing or cheek-facing surface of a restored tooth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000235 "Bill Duncan 01/05/2017:
 Some dental EHR systems use the letter \"F\" for facial surfaces rather than \"L\" for labial surfaces. The reason is that \"L\" is also used for the lingual surface.")
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000235 "Gopikrishnan M. Chandrasekharan 07/12/2023:
@@ -3809,7 +3809,7 @@ SubClassOf(obo:OHD_0000235 obo:OHD_0000208)
 
 # Class: obo:OHD_0000236 (endodontically restored tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000236 "A restored tooth in which some portion of the tooth's root or pulp has been replaced by dental restoration material as a result of the tooth undergoing an endodontic restorative procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000236 "A restored tooth in which some portion of the tooth's root or pulp has been replaced by dental restoration material as a result of the tooth undergoing an endodontic restorative procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000236 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000236 "2022-12-06T02:00:27Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000236 "endodontically restored tooth"@en)
@@ -3818,7 +3818,7 @@ SubClassOf(obo:OHD_0000236 obo:OHD_0000189)
 
 # Class: obo:OHD_0000237 (coronally restored tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000237 "A restored tooth in which some portion of enamel in the tooth's crown has been restored by dental restoration material as the result of the tooth undergoing either a crown procedure or intracoronal restoration procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000237 "A restored tooth in which some portion of enamel in the tooth's crown has been restored by dental restoration material as the result of the tooth undergoing either a crown procedure or intracoronal restoration procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000237 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000237 "2022-12-06T01:55:01Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000237 "coronally restored tooth"@en)
@@ -3827,7 +3827,7 @@ SubClassOf(obo:OHD_0000237 obo:OHD_0000189)
 
 # Class: obo:OHD_0000238 (extracoronally restored tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000238 "A coronally restored tooth in which all or part of the natural dental crown is repalced by an artificial crown as a result of the tooth undergoing an crown procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000238 "A coronally restored tooth in which all or part of the natural dental crown is repalced by an artificial crown as a result of the tooth undergoing an crown procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000238 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000238 "2022-12-06T01:56:50Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000238 "extracoronally restored tooth"@en)
@@ -3836,7 +3836,7 @@ SubClassOf(obo:OHD_0000238 obo:OHD_0000237)
 
 # Class: obo:OHD_0000239 (intracoronally restored tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000239 "A coronally restored tooth in which dental restoration material is placed into a site that is located in the crown of the tooth as the result of the tooth undergoing an intracoronal restoration procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000239 "A coronally restored tooth in which dental restoration material is placed into a site that is located in the crown of the tooth as the result of the tooth undergoing an intracoronal restoration procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000239 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000239 "2022-12-06T01:57:51Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000239 "intracoronally restored tooth"@en)
@@ -3845,7 +3845,7 @@ SubClassOf(obo:OHD_0000239 obo:OHD_0000237)
 
 # Class: obo:OHD_0000240 (veneer surface restored tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000240 "A coronally restored tooth in which a thin layer of material (i.e., a veneer) has been placed over one or more surfaces of the tooth as a result of the tooth undergoing a veneer restoration procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000240 "A coronally restored tooth in which a thin layer of material (i.e., a veneer) has been placed over one or more surfaces of the tooth as a result of the tooth undergoing a veneer restoration procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000240 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000240 "2022-12-06T01:59:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000240 "veneer surface restored tooth"@en)
@@ -3854,7 +3854,7 @@ SubClassOf(obo:OHD_0000240 obo:OHD_0000237)
 
 # Class: obo:OHD_0000241 (apicoectomy procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000241 "An endodontic restorative procedure during which a tooth's root tip is removed and a root end cavity is prepared and filled with dental restoration material.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000241 "An endodontic restorative procedure during which a tooth's root tip is removed and a root end cavity is prepared and filled with dental restoration material."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000241 "https://en.wikipedia.org/wiki/Apicoectomy")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000241 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000241 "2022-12-06T02:20:26Z"^^xsd:dateTime)
@@ -3863,7 +3863,7 @@ SubClassOf(obo:OHD_0000241 obo:OHD_0000242)
 
 # Class: obo:OHD_0000242 (endodontic restorative procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000242 "A tooth restoration procedure during which some portion of the tooth's root or pulp is replaced by dental restoration material.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000242 "A tooth restoration procedure during which some portion of the tooth's root or pulp is replaced by dental restoration material."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000242 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000242 "2022-12-06T01:52:43Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000242 "endodontic restorative procedure"@en)
@@ -3872,7 +3872,7 @@ SubClassOf(obo:OHD_0000242 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000236)
 
 # Class: obo:OHD_0000243 (surgical endodontic procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000243 "A surgical dental procedure that is performed on the pulp chamber and/or root canal of a tooth, or a part thereof.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000243 "A surgical dental procedure that is performed on the pulp chamber and/or root canal of a tooth, or a part thereof."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000243 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000243 "2022-12-06T02:26:59Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000243 "surgical endodontic procedure"@en)
@@ -3880,7 +3880,7 @@ SubClassOf(obo:OHD_0000243 obo:OHD_0000044)
 
 # Class: obo:OHD_0000244 (root amputation procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000244 "A surgical endodontic procure during which a root is removed from a multi-root tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000244 "A surgical endodontic procure during which a root is removed from a multi-root tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000244 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000244 "2022-12-06T02:35:48Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000244 "root amputation procedure"@en)
@@ -3888,7 +3888,7 @@ SubClassOf(obo:OHD_0000244 obo:OHD_0000243)
 
 # Class: obo:OHD_0000245 (prosthodontics procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000245 "A dental procedure during which some part of the mouth is replaced by or fitted for a prothesis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000245 "A dental procedure during which some part of the mouth is replaced by or fitted for a prothesis."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000245 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000245 "2022-12-06T01:49:03Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000245 "prosthodontics procedure"@en)
@@ -3897,7 +3897,7 @@ SubClassOf(obo:OHD_0000245 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000301)
 
 # Class: obo:OHD_0000246 (fixed prosthodontics procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000246 "A prosthodontics procedure during which a prosthesis is permanently attached to some part of the mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000246 "A prosthodontics procedure during which a prosthesis is permanently attached to some part of the mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000246 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000246 "2022-12-06T04:06:45Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000246 "fixed prosthodontics procedure"@en)
@@ -3906,7 +3906,7 @@ SubClassOf(obo:OHD_0000246 obo:OHD_0000245)
 
 # Class: obo:OHD_0000247 (removable prosthodontics procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000247 "A prosthodontics procedure during which a removable prosthesis is either constructed or fitted to the patient's mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000247 "A prosthodontics procedure during which a removable prosthesis is either constructed or fitted to the patient's mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000247 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000247 "2022-12-06T04:08:52Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000247 "removable prosthodontics procedure"@en)
@@ -3914,7 +3914,7 @@ SubClassOf(obo:OHD_0000247 obo:OHD_0000245)
 
 # Class: obo:OHD_0000248 (dental implant procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000248 "A fixed prosthodontics procedure in which a dental implant is permanently attached to the jaw.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000248 "A fixed prosthodontics procedure in which a dental implant is permanently attached to the jaw."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000248 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000248 "2022-12-06T04:37:27Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000248 "dental implant procedure"@en)
@@ -3923,7 +3923,7 @@ SubClassOf(obo:OHD_0000248 obo:OHD_0000246)
 
 # Class: obo:OHD_0000249 (complete denture procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000249 "A removable prosthodontics procedure in which the prosthesis being constructed or fitted replaces all of the patient's teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000249 "A removable prosthodontics procedure in which the prosthesis being constructed or fitted replaces all of the patient's teeth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000249 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000249 "2022-12-06T04:10:46Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000249 "complete denture procedure"@en)
@@ -3932,7 +3932,7 @@ SubClassOf(obo:OHD_0000249 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000254)
 
 # Class: obo:OHD_0000250 (removable partial denture procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000250 "A removable prosthodontics procedure in which the prosthesis being constructed or fitted replaces some but not all of the patient's teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000250 "A removable prosthodontics procedure in which the prosthesis being constructed or fitted replaces some but not all of the patient's teeth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000250 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000250 "2022-12-06T04:12:21Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000250 "removable partial denture procedure"@en)
@@ -3941,7 +3941,7 @@ SubClassOf(obo:OHD_0000250 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000252)
 
 # Class: obo:OHD_0000251 (implant supported partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000251 "A fixed partial denture that is suppored and retained by underlying tissue and one or more dental implants.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000251 "A fixed partial denture that is suppored and retained by underlying tissue and one or more dental implants."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000251 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000251 "2022-12-06T03:41:04Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000251 "implant supported partial denture"@en)
@@ -3949,7 +3949,7 @@ SubClassOf(obo:OHD_0000251 obo:OHD_0000312)
 
 # Class: obo:OHD_0000252 (removable partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000252 "A partial denture that is designed and constructed to be removed readily from the mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000252 "A partial denture that is designed and constructed to be removed readily from the mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000252 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000252 "2022-12-06T03:54:24Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000252 "removable partial denture"@en)
@@ -3957,7 +3957,7 @@ SubClassOf(obo:OHD_0000252 obo:OHD_0000310)
 
 # Class: obo:OHD_0000253 (complete denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000253 "A prosthesis that replaces all the natural teeth and associated structures in either the maxilla or mandible (or both).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000253 "A prosthesis that replaces all the natural teeth and associated structures in either the maxilla or mandible (or both)."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000253 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000253 "2022-12-06T03:32:49Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000253 "complete denture"@en)
@@ -3965,7 +3965,7 @@ SubClassOf(obo:OHD_0000253 obo:OHD_0000301)
 
 # Class: obo:OHD_0000254 (complete removable denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000254 "A complete denture that can be easily removed from a mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000254 "A complete denture that can be easily removed from a mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000254 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000254 <https://orcid.org/0009-0002-7282-0836>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000254 "2022-12-06T03:35:25Z"^^xsd:dateTime)
@@ -3974,7 +3974,7 @@ SubClassOf(obo:OHD_0000254 obo:OHD_0000253)
 
 # Class: obo:OHD_0000255 (complete fixed denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000255 "A complete denture that is perminately attached to the mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000255 "A complete denture that is perminately attached to the mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000255 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000255 "2022-12-06T03:33:42Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000255 "complete fixed denture"@en)
@@ -3982,7 +3982,7 @@ SubClassOf(obo:OHD_0000255 obo:OHD_0000253)
 
 # Class: obo:OHD_0000256 (complete full denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000256 "A complete denture that replaces all the natural teeth and associated structures in both the maxilla and mandible.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000256 "A complete denture that replaces all the natural teeth and associated structures in both the maxilla and mandible."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000256 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000256 "2022-12-06T03:34:14Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000256 "complete full denture"@en)
@@ -3990,7 +3990,7 @@ SubClassOf(obo:OHD_0000256 obo:OHD_0000253)
 
 # Class: obo:OHD_0000257 (complete lower denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000257 "A complete denture that replaces all the natural teeth and associated structures in the mandible.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000257 "A complete denture that replaces all the natural teeth and associated structures in the mandible."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000257 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000257 "2022-12-06T03:34:47Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000257 "complete lower denture"@en)
@@ -4006,7 +4006,7 @@ SubClassOf(obo:OHD_0000258 obo:OGMS_0000065)
 
 # Class: obo:OHD_0000259 (dental implant)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000259 "A prosthetic tooth with an anchoring structure surgically implanted beneath the mucosal or periosteal layer or in the bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000259 "A prosthetic tooth with an anchoring structure surgically implanted beneath the mucosal or periosteal layer or in the bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000259 "http://medical-dictionary.thefreedictionary.com/tooth+implant")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000259 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000259 "2022-12-06T04:03:18Z"^^xsd:dateTime)
@@ -4015,7 +4015,7 @@ SubClassOf(obo:OHD_0000259 obo:OHD_0000302)
 
 # Class: obo:OHD_0000260 (tooth disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000260 "A disorder that is part of a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000260 "A disorder that is part of a tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000260 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000260 "2023-06-06T21:30:39Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000260 "tooth disorder"@en)
@@ -4024,7 +4024,7 @@ SubClassOf(obo:OHD_0000260 obo:OHD_0000414)
 
 # Class: obo:OHD_0000261 (tooth abfraction lesion)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "SNOMED CT \"Abfraction (disorder)\" (SCTID: 109750005)") obo:IAO_0000115 obo:OHD_0000261 "A mechanical tooth lesion formed as a result of the tooth being fatigued, flexed, and deformed by biomechanical loading of the tooth. Tooth abfactions are primarily found in the cervical region of the tooth.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "SNOMED CT \"Abfraction (disorder)\" (SCTID: 109750005)") obo:IAO_0000115 obo:OHD_0000261 "A mechanical tooth lesion formed as a result of the tooth being fatigued, flexed, and deformed by biomechanical loading of the tooth. Tooth abfactions are primarily found in the cervical region of the tooth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000261 "Tooth abfractions are usually wedge-shaped lesions with sharp-line angles, but sometimes circular invaginations on occlusal surfaces.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000261 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000261 <https://orcid.org/0009-0006-7251-3026>)
@@ -4046,7 +4046,7 @@ SubClassOf(obo:OHD_0000262 ObjectSomeValuesFrom(obo:RO_0002354 ObjectUnionOf(obo
 
 # Class: obo:OHD_0000263 (tooth erosive lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000263 "A non-carious tooth lesion that is formed as result of the tooth being exposed to acids.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000263 "A non-carious tooth lesion that is formed as result of the tooth being exposed to acids."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000263 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000263 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000263 "2023-06-06T21:31:50Z"^^xsd:dateTime)
@@ -4057,7 +4057,7 @@ SubClassOf(obo:OHD_0000263 ObjectSomeValuesFrom(obo:RO_0002354 obo:ECTO_9002146)
 
 # Class: obo:OHD_0000264 (tooth abrasive lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000264 "A tooth friction lesion that is formed as result of some abrasive process.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000264 "A tooth friction lesion that is formed as result of some abrasive process."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000264 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000264 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000264 "2023-06-06T21:33:29Z"^^xsd:dateTime)
@@ -4067,7 +4067,7 @@ SubClassOf(obo:OHD_0000264 ObjectSomeValuesFrom(obo:RO_0002354 obo:OHD_0000282))
 
 # Class: obo:OHD_0000265 (arrested carious lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000265 "A carious tooth lesion that resulted from some tooth decay but the infected region is not currently decaying.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000265 "A carious tooth lesion that resulted from some tooth decay but the infected region is not currently decaying."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000265 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000265 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000265 "2023-06-06T21:37:28Z"^^xsd:dateTime)
@@ -4076,7 +4076,7 @@ SubClassOf(obo:OHD_0000265 obo:OHD_0000021)
 
 # Class: obo:OHD_0000266 (active carious lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000266 "A carious tooth lesion that is currently undergoing the process of tooth decay.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000266 "A carious tooth lesion that is currently undergoing the process of tooth decay."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000266 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000266 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000266 "2023-06-06T21:37:54Z"^^xsd:dateTime)
@@ -4085,7 +4085,7 @@ SubClassOf(obo:OHD_0000266 obo:OHD_0000021)
 
 # Class: obo:OHD_0000267 (enamel carious lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000267 "A carious tooth lesion that is found only within the enamel.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000267 "A carious tooth lesion that is found only within the enamel."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000267 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000267 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000267 "2023-06-06T21:38:37Z")
@@ -4095,7 +4095,7 @@ SubClassOf(obo:OHD_0000267 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_00017
 
 # Class: obo:OHD_0000268 (dentine carious lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000268 "A carious tooth legion that has extended to the dentine.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000268 "A carious tooth legion that has extended to the dentine."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000268 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000268 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000268 "2023-06-06T21:39:01Z"^^xsd:dateTime)
@@ -4105,7 +4105,7 @@ SubClassOf(obo:OHD_0000268 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_00017
 
 # Class: obo:OHD_0000269 (tooth root carious lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000269 "A carious tooth lesion that is either wholly or partially part of the tooth root.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000269 "A carious tooth lesion that is either wholly or partially part of the tooth root."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000269 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000269 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000269 "2023-06-06T21:39:44Z"^^xsd:dateTime)
@@ -4116,7 +4116,7 @@ SubClassOf(obo:OHD_0000269 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_00036
 
 # Class: obo:OHD_0000270 (non-carious tooth lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000270 "A tooth disorder that is not formed by tooth decay.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000270 "A tooth disorder that is not formed by tooth decay."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000270 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000270 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000270 "2023-06-07T14:15:31Z"^^xsd:dateTime)
@@ -4127,7 +4127,7 @@ SubClassOf(obo:OHD_0000270 obo:OHD_0000260)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000271 "A tooth lesion caused by brushing too hard.")
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000271 "A tooth lesion caused by bruxism.")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000271 "A non-carious tooth lesion that is the result of functional or parafunctional activity of the jaws or a process of friction or an abrasive process")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000271 "A non-carious tooth lesion that is the result of functional or parafunctional activity of the jaws or a process of friction or an abrasive process"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000271 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000271 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000271 "2023-06-08T16:19:59Z"^^xsd:dateTime)
@@ -4137,7 +4137,7 @@ SubClassOf(obo:OHD_0000271 obo:OHD_0000270)
 
 # Class: obo:OHD_0000272 (patient-reported favorable outcome)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000272 "A patient-reported outcome that reports a favorable outcome in regards to the patient's health.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000272 "A patient-reported outcome that reports a favorable outcome in regards to the patient's health."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000272 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000272 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000272 <https://orcid.org/0009-0003-7246-1252>)
@@ -4147,7 +4147,7 @@ SubClassOf(obo:OHD_0000272 obo:OHD_0005001)
 
 # Class: obo:OHD_0000274 (tooth cleaning process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000274 "A process during which the surface of the tooth is cleaned.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000274 "A process during which the surface of the tooth is cleaned."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000274 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000274 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000274 "2023-06-08T16:56:25Z"^^xsd:dateTime)
@@ -4157,7 +4157,7 @@ SubClassOf(obo:OHD_0000274 ObjectSomeValuesFrom(obo:RO_0000057 obo:UBERON_000109
 
 # Class: obo:OHD_0000275 (toothbrushing)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000275 "A tooth cleaning process during which an object is used to clean the tooth (or teeth) by applying a powder, paste, or liquid (i.e., dentifrice).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000275 "A tooth cleaning process during which an object is used to clean the tooth (or teeth) by applying a powder, paste, or liquid (i.e., dentifrice)."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000275 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000275 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000275 "2023-06-08T16:59:29Z"^^xsd:dateTime)
@@ -4167,7 +4167,7 @@ SubClassOf(obo:OHD_0000275 ObjectSomeValuesFrom(obo:RO_0000057 obo:OHD_0000284))
 
 # Class: obo:OHD_0000276 (sleep bruxism)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "PMCID: PMC6287494") obo:IAO_0000115 obo:OHD_0000276 "A bruxism that occurs during sleep and is characterised by rhythmic (phasic) or non-rhythmic (tonic) movements of the jaw.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "PMCID: PMC6287494") obo:IAO_0000115 obo:OHD_0000276 "A bruxism that occurs during sleep and is characterised by rhythmic (phasic) or non-rhythmic (tonic) movements of the jaw."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000276 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000276 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000276 "2023-06-06T21:39:37Z")
@@ -4176,7 +4176,7 @@ SubClassOf(obo:OHD_0000276 obo:OHD_0000407)
 
 # Class: obo:OHD_0000277 (tooth fracture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000277 "A tooth disorder that is an outcome of a ruture or break of some part of the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000277 "A tooth disorder that is an outcome of a ruture or break of some part of the tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000277 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000277 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000277 "2023-06-08T17:13:14Z"^^xsd:dateTime)
@@ -4185,7 +4185,7 @@ SubClassOf(obo:OHD_0000277 obo:OHD_0000260)
 
 # Class: obo:OHD_0000278 (dental implant body)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000278 "A prosthesis that forms the part of a prosthetic tooth  that is in direct contact with the bone and actually provides the fixation to the bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000278 "A prosthesis that forms the part of a prosthetic tooth  that is in direct contact with the bone and actually provides the fixation to the bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000278 "http://www.ptcdental.com/dentaldictionary/i/implant-body/")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000278 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000278 "2022-12-06T04:22:55Z"^^xsd:dateTime)
@@ -4195,7 +4195,7 @@ SubClassOf(obo:OHD_0000278 ObjectSomeValuesFrom(obo:BFO_0000050 obo:OHD_0000259)
 
 # Class: obo:OHD_0000279 (dental implant abutment)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000279 "A prosthesis that forms the part of a prosthetic tooth to which the restoration is attached and supports the restoration.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000279 "A prosthesis that forms the part of a prosthetic tooth to which the restoration is attached and supports the restoration."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000279 "Bill Duncan 07/26/2017:
 Implant abutments are conical-shaped, and are screwed into a dental implant integrated into the jawbone. Today, the most common form of implant abutments are made of tooth colored material to add a more natural look to the crown that covers the abutment. This type of abutment allows the crown to blend more appropriately with adjacent teeth as is the case with the high noble metal resin crowns and porcelain-fused to noble metal crowns.
 
@@ -4211,7 +4211,7 @@ SubClassOf(obo:OHD_0000279 ObjectSomeValuesFrom(obo:BFO_0000050 obo:OHD_0000259)
 
 # Class: obo:OHD_0000280 (dental implant crown)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000280 "A prosthesis that forms the part of a prosthetic tooth which provides the prosthetic tooth with the functionallity and appearance of a natural tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000280 "A prosthesis that forms the part of a prosthetic tooth which provides the prosthetic tooth with the functionallity and appearance of a natural tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000280 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000280 "2022-12-06T04:27:20Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000280 "dental implant crown"@en)
@@ -4220,7 +4220,7 @@ SubClassOf(obo:OHD_0000280 ObjectSomeValuesFrom(obo:BFO_0000050 obo:OHD_0000259)
 
 # Class: obo:OHD_0000281 (fixed prothesis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000281 "A prosthesis that is permanently attached attached to some part of the mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000281 "A prosthesis that is permanently attached attached to some part of the mouth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000281 "Bill Duncan 07/26/2017:
 This class is used to group dental implants and fixed dentures under one term.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000281 <https://orcid.org/0000-0001-9625-1899>)
@@ -4230,7 +4230,7 @@ SubClassOf(obo:OHD_0000281 obo:OHD_0000301)
 
 # Class: obo:OHD_0000282 (tooth abrasive process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000282 "A process during which the tooth is affected by an abrasive material.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000282 "A process during which the tooth is affected by an abrasive material."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000282 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000282 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000282 "2023-06-09T16:17:51Z"^^xsd:dateTime)
@@ -4240,7 +4240,7 @@ SubClassOf(obo:OHD_0000282 obo:BFO_0000015)
 
 # Class: obo:OHD_0000283 (subperiosteal implant framework)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000283 "A dental implant body fabricated to fit the supporting areas of mandible or maxilla with permucosal extensions for support and attachment of abutments.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000283 "A dental implant body fabricated to fit the supporting areas of mandible or maxilla with permucosal extensions for support and attachment of abutments."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000283 "http://dentalimplants.uchc.edu/about/types.html")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000283 "http://implantdirect.co/ai/implantcatalogpdf/glossary.pdf")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000283 <https://orcid.org/0000-0001-9625-1899>)
@@ -4250,7 +4250,7 @@ SubClassOf(obo:OHD_0000283 obo:OHD_0000278)
 
 # Class: obo:OHD_0000284 (abrasive material)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000284 "A material entity of a certain hardness and density that helps remove material from the surface of an entity.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000284 "A material entity of a certain hardness and density that helps remove material from the surface of an entity."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000284 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000284 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000284 "2023-06-09T16:29:17Z"^^xsd:dateTime)
@@ -4259,7 +4259,7 @@ SubClassOf(obo:OHD_0000284 obo:BFO_0000040)
 
 # Class: obo:OHD_0000285 (mini dental implant body)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000285 "A dental implant body that is less that 3mm in diameter.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000285 "A dental implant body that is less that 3mm in diameter."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000285 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000285 "2022-12-06T04:24:40Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000285 "mini dental implant body"@en)
@@ -4267,7 +4267,7 @@ SubClassOf(obo:OHD_0000285 obo:OHD_0000278)
 
 # Class: obo:OHD_0000286 (pulp capping procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000286 "An endodontic restorative procedure during which material is placed over exposed or nearly dental pulp in order to protect and promote healing of the dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000286 "An endodontic restorative procedure during which material is placed over exposed or nearly dental pulp in order to protect and promote healing of the dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000286 "https://en.wikipedia.org/wiki/Pulp_capping")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000286 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000286 "2022-12-06T02:23:54Z"^^xsd:dateTime)
@@ -4276,7 +4276,7 @@ SubClassOf(obo:OHD_0000286 obo:OHD_0000242)
 
 # Class: obo:OHD_0000287 (awake bruxism)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "PMCID: PMC6287494") obo:IAO_0000115 obo:OHD_0000287 "A bruxism that occurs during wakeful-ness and is characterised by repetitive or sustained tooth contact and/or by bracing or thrusting of the mandible.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "PMCID: PMC6287494") obo:IAO_0000115 obo:OHD_0000287 "A bruxism that occurs during wakeful-ness and is characterised by repetitive or sustained tooth contact and/or by bracing or thrusting of the mandible."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000287 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000287 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000287 "2023-06-06T21:38:37Z")
@@ -4285,7 +4285,7 @@ SubClassOf(obo:OHD_0000287 obo:OHD_0000407)
 
 # Class: obo:OHD_0000288 (patient-reported unfavorable outcome)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000288 "A patient-reported outcome that reports an ufavorable outcome in regards to the patient's health.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000288 "A patient-reported outcome that reports an ufavorable outcome in regards to the patient's health."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000288 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000288 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000288 <https://orcid.org/0009-0003-7246-1252>)
@@ -4295,7 +4295,7 @@ SubClassOf(obo:OHD_0000288 obo:OHD_0005001)
 
 # Class: obo:OHD_0000289 (pulpal regeneration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000289 "A surgical endodontic procedure during which medications are placed inside the pulp chamber in order to induce the formation of living replacement tissue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000289 "A surgical endodontic procedure during which medications are placed inside the pulp chamber in order to induce the formation of living replacement tissue."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000289 "http://www.neendosol.com/procedures/pulpal-regeneration/")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000289 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000289 "2022-12-06T02:34:17Z"^^xsd:dateTime)
@@ -4304,7 +4304,7 @@ SubClassOf(obo:OHD_0000289 obo:OHD_0000243)
 
 # Class: obo:OHD_0000290 (tooth friction lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000290 "A mechnical tooth lesion that formed as a result of some friction process.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000290 "A mechnical tooth lesion that formed as a result of some friction process."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000290 "A tooth friction lesion is caused by a friction process involving an external object. For example, the clasp of an ill-fitting denture, pipe stem of a tobacco pipe, friction lesion of the interproximal areas caused by vigorous use of a tooth pick etc. An abrasive material is not involved in creating the friction lesion.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000290 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000290 <https://orcid.org/0009-0006-7251-3026>)
@@ -4314,7 +4314,7 @@ SubClassOf(obo:OHD_0000290 obo:OHD_0000271)
 
 # Class: obo:OHD_0000291 (removable maxillary partial denture procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000291 "A removable partial denture procedure in which the prosthesis being constructed or fitted replaces some but not all of the patient's maxillary teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000291 "A removable partial denture procedure in which the prosthesis being constructed or fitted replaces some but not all of the patient's maxillary teeth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000291 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000291 "2022-12-06T04:15:55Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000291 "removable maxillary partial denture procedure"@en)
@@ -4322,7 +4322,7 @@ SubClassOf(obo:OHD_0000291 obo:OHD_0000250)
 
 # Class: obo:OHD_0000292 (removable mandibular partial denture procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000292 "A removable partial denture procedure in which the prosthesis being constructed or fitted replaces some but not all of the patient's mandibular teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000292 "A removable partial denture procedure in which the prosthesis being constructed or fitted replaces some but not all of the patient's mandibular teeth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000292 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000292 "2022-12-06T04:15:07Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000292 "removable mandibular partial denture procedure"@en)
@@ -4330,7 +4330,7 @@ SubClassOf(obo:OHD_0000292 obo:OHD_0000250)
 
 # Class: obo:OHD_0000293 (interim dental implant body)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000293 "A dental implant body that is placed in the mouth for short duration of time in order to allow adequate time for healing or completion of definitive treatment planning.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000293 "A dental implant body that is placed in the mouth for short duration of time in order to allow adequate time for healing or completion of definitive treatment planning."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000293 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000293 "2022-12-06T04:24:01Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000293 "interim dental implant body"@en)
@@ -4338,7 +4338,7 @@ SubClassOf(obo:OHD_0000293 obo:OHD_0000278)
 
 # Class: obo:OHD_0000294 (ceramic implant crown)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000294 "A dental implant crown constructed out of ceramic.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000294 "A dental implant crown constructed out of ceramic."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000294 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000294 "2022-12-06T04:28:56Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000294 "ceramic implant crown"@en)
@@ -4355,7 +4355,7 @@ SubClassOf(obo:OHD_0000295 obo:OHD_0000280)
 
 # Class: obo:OHD_0000296 (dental implant crown attachment procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000296 "A fixed prosthodontics procedure during which an artificial crown is attached to an dental implant abutment.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000296 "A fixed prosthodontics procedure during which an artificial crown is attached to an dental implant abutment."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000296 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000296 "2022-12-06T04:43:23Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000296 "dental implant crown attachment procedure"@en)
@@ -4364,7 +4364,7 @@ SubClassOf(obo:OHD_0000296 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000280)
 
 # Class: obo:OHD_0000297 (ceramic dental implant crown attachement procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000297 "A dental implant crown attachment procedure in which the implant crown is composed of ceramic.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000297 "A dental implant crown attachment procedure in which the implant crown is composed of ceramic."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000297 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000297 "2022-12-06T04:44:43Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000297 "ceramic dental implant crown attachement procedure"@en)
@@ -4373,7 +4373,7 @@ SubClassOf(obo:OHD_0000297 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000294)
 
 # Class: obo:OHD_0000298 (porcelain fused to metal dental implant crown attachement procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000298 "A dental implant crown attachment procedure in which the implant crown is composed of porcelain fused to metal.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000298 "A dental implant crown attachment procedure in which the implant crown is composed of porcelain fused to metal."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000298 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000298 "2022-12-06T04:46:37Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000298 "porcelain fused to metal dental implant crown attachement procedure"@en)
@@ -4382,7 +4382,7 @@ SubClassOf(obo:OHD_0000298 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000295)
 
 # Class: obo:OHD_0000299 (dental implant abutment attachement procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000299 "A fixed prosthodontics procedure during which an abutment is attached to an implant body.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000299 "A fixed prosthodontics procedure during which an abutment is attached to an implant body."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000299 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000299 "2022-12-06T04:39:09Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000299 "dental implant abutment attachement procedure"@en)
@@ -4391,7 +4391,7 @@ SubClassOf(obo:OHD_0000299 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000279)
 
 # Class: obo:OHD_0000300 (dental implant retainer attachement procedure for fixed partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000300 "A dental implant abutment attachment procedure during which a retainer for a fixed partial denture is attached to an implant body.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000300 "A dental implant abutment attachment procedure during which a retainer for a fixed partial denture is attached to an implant body."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000300 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000300 "2022-12-06T04:40:12Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000300 "dental implant retainer attachement procedure for fixed partial denture"@en)
@@ -4400,72 +4400,72 @@ SubClassOf(obo:OHD_0000300 ObjectSomeValuesFrom(obo:OBI_0000299 obo:OHD_0000358)
 
 # Class: obo:OHD_0000301 (prosthesis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000301 "A processed material that bears a prothetic role.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000301 "A processed material that bears a prothetic role."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000301 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000301 "prosthesis")
+AnnotationAssertion(rdfs:label obo:OHD_0000301 "prosthesis"@en)
 EquivalentClasses(obo:OHD_0000301 ObjectIntersectionOf(obo:OBI_0000047 ObjectSomeValuesFrom(obo:BFO_0000053 obo:OHD_0000314)))
 SubClassOf(obo:OHD_0000301 obo:OBI_0000047)
 
 # Class: obo:OHD_0000302 (prosthetic tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000302 "A prosthesis that has been fabricated for use as a substitute for a natural tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000302 "A prosthesis that has been fabricated for use as a substitute for a natural tooth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000302 "usually made of porcelain or plastic")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000302 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000302 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 689")
-AnnotationAssertion(rdfs:label obo:OHD_0000302 "prosthetic tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000302 "prosthetic tooth"@en)
 SubClassOf(obo:OHD_0000302 obo:OHD_0000301)
 SubClassOf(obo:OHD_0000302 ObjectSomeValuesFrom(obo:BFO_0000053 obo:OHD_0000315))
 
 # Class: obo:OHD_0000303 (direct restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000303 "A tooth restoration procedure in which the dental restoration material is placed in the tooth via some direct dental restoration material combination process.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000303 "A tooth restoration procedure in which the dental restoration material is placed in the tooth via some direct dental restoration material combination process."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000303 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000303 "direct restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000303 "direct restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000303 ObjectIntersectionOf(obo:OHD_0000004 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000037)))
 SubClassOf(obo:OHD_0000303 obo:OHD_0000004)
 
 # Class: obo:OHD_0000304 (indirect restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000304 "A tooth restoration procedure in which the dental restoration material is placed in the tooth via some dental material tooth attachment process.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000304 "A tooth restoration procedure in which the dental restoration material is placed in the tooth via some dental material tooth attachment process."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000304 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000304 "indirect restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000304 "indirect restoration procedure"@en)
 EquivalentClasses(obo:OHD_0000304 ObjectIntersectionOf(obo:OHD_0000004 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000038)))
 SubClassOf(obo:OHD_0000304 obo:OHD_0000004)
 
 # Class: obo:OHD_0000305 (3/4 crown restoration procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000305 "A crown restoration procedure in which 3 of the 4 surfaces on an anterior tooth is restored. The dental restoration material extends to (or almost to) the gum line.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000305 "A crown restoration procedure in which 3 of the 4 surfaces on an anterior tooth is restored. The dental restoration material extends to (or almost to) the gum line."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000305 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000305 "3/4 crown restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000305 "3/4 crown restoration procedure"@en)
 SubClassOf(obo:OHD_0000305 obo:OHD_0000033)
 SubClassOf(obo:OHD_0000305 ObjectSomeValuesFrom(obo:OBI_0000293 obo:OHD_0000307))
 
 # Class: obo:OHD_0000306 (dental material fusion process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000306 "A dental material combination process in which one or more materials forms a substructure and then one or more materials are fused (or baked) onto this substructure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000306 "A dental material combination process in which one or more materials forms a substructure and then one or more materials are fused (or baked) onto this substructure."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000306 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000306 "dental material fusion process")
+AnnotationAssertion(rdfs:label obo:OHD_0000306 "dental material fusion process"@en)
 SubClassOf(obo:OHD_0000306 obo:OHD_0000349)
 
 # Class: obo:OHD_0000307 (Anterior Tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000307 "A tooth that is either an incisor or a canine.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000307 "A tooth that is either an incisor or a canine."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000307 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000307 "Anterior Tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000307 "Anterior Tooth"@en)
 EquivalentClasses(obo:OHD_0000307 ObjectUnionOf(obo:UBERON_0001098 obo:UBERON_0003674))
 SubClassOf(obo:OHD_0000307 obo:UBERON_0001091)
 
 # Class: obo:OHD_0000308 (Posterior Tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000308 "A tooth that is either a molar or premolar.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000308 "A tooth that is either a molar or premolar."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000308 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000308 "Posterior Tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000308 "Posterior Tooth"@en)
 EquivalentClasses(obo:OHD_0000308 ObjectUnionOf(obo:UBERON_0003655 obo:UBERON_0007120))
 SubClassOf(obo:OHD_0000308 obo:UBERON_0001091)
 
 # Class: obo:OHD_0000309 (dental implant retainer attachement procedure for ceramic fixed partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000309 "A dental implant retainer attachement procedure for fixed partial denture in which the retainer being attached to the implant body is to be used as a retainer for a ceramic fixed partial denture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000309 "A dental implant retainer attachement procedure for fixed partial denture in which the retainer being attached to the implant body is to be used as a retainer for a ceramic fixed partial denture."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000309 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000309 "2022-12-06T04:41:10Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000309 "dental implant retainer attachement procedure for ceramic fixed partial denture"@en)
@@ -4474,30 +4474,30 @@ SubClassOf(obo:OHD_0000309 obo:OHD_0000300)
 # Class: obo:OHD_0000310 (partial denture)
 
 AnnotationAssertion(obo:IAO_0000111 obo:OHD_0000310 "partial denture")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000310 "A prosthesis that replaces one or more, but less than all, of the natural teeth and associated structures.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000310 "A prosthesis that replaces one or more, but less than all, of the natural teeth and associated structures."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000310 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000310 "partial dental prothesis")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000310 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 175")
-AnnotationAssertion(rdfs:label obo:OHD_0000310 "partial denture")
+AnnotationAssertion(rdfs:label obo:OHD_0000310 "partial denture"@en)
 SubClassOf(obo:OHD_0000310 obo:OHD_0000301)
 SubClassOf(obo:OHD_0000310 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000302))
 
 # Class: obo:OHD_0000311 (tooth-supported partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000311 "A fixed partial denture that is suppored and retained by underlying tissue and some or all of the remaining teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000311 "A fixed partial denture that is suppored and retained by underlying tissue and some or all of the remaining teeth."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000311 "Dan Caplan 12/13/2014:
 Mosby's definition is not quite corrrect. The support could also include other teeth that are not adjacent to the endentulous area. The important point is that the prosthesis is supported by existing teeth (wherever they are in the arch), and not by the gingiva.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000311 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000311 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 175-176")
-AnnotationAssertion(rdfs:label obo:OHD_0000311 "tooth-supported partial denture")
+AnnotationAssertion(rdfs:label obo:OHD_0000311 "tooth-supported partial denture"@en)
 SubClassOf(obo:OHD_0000311 obo:OHD_0000312)
 
 # Class: obo:OHD_0000312 (fixed partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000312 "A partial denture that is permanently attached to prepared natural teeth, roots, or implants.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000312 "A partial denture that is permanently attached to prepared natural teeth, roots, or implants."@en)
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000312 "bridge")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000312 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 175")
-AnnotationAssertion(rdfs:label obo:OHD_0000312 "fixed partial denture")
+AnnotationAssertion(rdfs:label obo:OHD_0000312 "fixed partial denture"@en)
 SubClassOf(obo:OHD_0000312 obo:OHD_0000310)
 
 # Class: obo:OHD_0000313 (fixed partial denture restoration procedure)
@@ -4506,314 +4506,314 @@ AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000313 "A tooth restoration procedu
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000313 "A tooth restoration procedure in which a fixed partial denture (i.e., bridge) is attached to the supporting teeth.")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000313 "bridge restoration procedure")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000313 <https://orcid.org/0000-0001-9625-1899>)
-AnnotationAssertion(rdfs:label obo:OHD_0000313 "fixed partial denture restoration procedure")
+AnnotationAssertion(rdfs:label obo:OHD_0000313 "fixed partial denture restoration procedure"@en)
 SubClassOf(obo:OHD_0000313 obo:OHD_0000004)
 
 # Class: obo:OHD_0000314 (prosthetic role)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000314 "A glass eye (see  http://en.wikipedia.org/wiki/Ocular_prosthesis)")
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000314 "A prothetic hand (see http://bebionic.com)")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000314 "A material to be added role that inheres in a material entity that replaces some missing body part.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000314 "A material to be added role that inheres in a material entity that replaces some missing body part."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000314 "Bill Duncan / Alan Ruttenber 12/16/2014:
 
 Prosthics may be either functional for non-functional. For example, a glass eye bears a prosthetic role, but it does not see.")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000314 "Alan Ruttenberg")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000314 "Bill Dunan")
-AnnotationAssertion(rdfs:label obo:OHD_0000314 "prosthetic role")
+AnnotationAssertion(rdfs:label obo:OHD_0000314 "prosthetic role"@en)
 SubClassOf(obo:OHD_0000314 obo:OBI_0000319)
 SubClassOf(obo:OHD_0000314 ObjectSomeValuesFrom(obo:BFO_0000052 obo:BFO_0000040))
 
 # Class: obo:OHD_0000315 (functional prosthetic role)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000315 "A prosthic hand")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000315 "A prosthetic role that is realized by activities in which the material entity (bearing the role) is used a manner that is similar to how the body part that the prosthesis replaces would be used.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000315 "A prosthetic role that is realized by activities in which the material entity (bearing the role) is used a manner that is similar to how the body part that the prosthesis replaces would be used."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000315 "Alan Ruttenberg")
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000315 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000315 "functional prosthetic role")
+AnnotationAssertion(rdfs:label obo:OHD_0000315 "functional prosthetic role"@en)
 SubClassOf(obo:OHD_0000315 obo:OHD_0000314)
 
 # Class: obo:OHD_0000316 (pontic)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000316 "A prothetic tooth that is part of a fixed partial denture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000316 "A prothetic tooth that is part of a fixed partial denture."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000316 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000316 "pontic")
+AnnotationAssertion(rdfs:label obo:OHD_0000316 "pontic"@en)
 EquivalentClasses(obo:OHD_0000316 ObjectIntersectionOf(obo:OHD_0000302 ObjectSomeValuesFrom(obo:BFO_0000050 obo:OHD_0000312)))
 SubClassOf(obo:OHD_0000316 obo:OHD_0000302)
 
 # Class: obo:OHD_0000317 (prosthetic right upper third secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000317 "A prosthetic tooth that is used a substitute for a right upper third secondary molar tooth (tooth 1).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000317 "A prosthetic tooth that is used a substitute for a right upper third secondary molar tooth (tooth 1)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000317 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000317 "prosthetic tooth 1")
-AnnotationAssertion(rdfs:label obo:OHD_0000317 "prosthetic right upper third secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000317 "prosthetic right upper third secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000317 obo:OHD_0000302)
 
 # Class: obo:OHD_0000318 (prosthetic right upper second secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000318 "A prosthetic tooth that is used a substitute for a right upper second secondary molar tooth (tooth 2).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000318 "A prosthetic tooth that is used a substitute for a right upper second secondary molar tooth (tooth 2)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000318 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000318 "prosthetic tooth 2")
-AnnotationAssertion(rdfs:label obo:OHD_0000318 "prosthetic right upper second secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000318 "prosthetic right upper second secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000318 obo:OHD_0000302)
 
 # Class: obo:OHD_0000319 (prosthetic right upper first secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000319 "A prosthetic tooth that is used a substitute for a right upper first secondary molar tooth (tooth 3).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000319 "A prosthetic tooth that is used a substitute for a right upper first secondary molar tooth (tooth 3)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000319 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000319 "prosthetic tooth 3")
-AnnotationAssertion(rdfs:label obo:OHD_0000319 "prosthetic right upper first secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000319 "prosthetic right upper first secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000319 obo:OHD_0000302)
 
 # Class: obo:OHD_0000320 (prosthetic right upper second secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000320 "A prosthetic tooth that is used a substitute for a right upper second secondary premolar tooth (tooth 4).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000320 "A prosthetic tooth that is used a substitute for a right upper second secondary premolar tooth (tooth 4)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000320 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000320 "prosthetic tooth 4")
-AnnotationAssertion(rdfs:label obo:OHD_0000320 "prosthetic right upper second secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000320 "prosthetic right upper second secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000320 obo:OHD_0000302)
 
 # Class: obo:OHD_0000321 (prosthetic right upper first secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000321 "A prosthetic tooth that is used a substitute for a right upper first secondary premolar tooth (tooth 5).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000321 "A prosthetic tooth that is used a substitute for a right upper first secondary premolar tooth (tooth 5)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000321 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000321 "prosthetic tooth 5")
-AnnotationAssertion(rdfs:label obo:OHD_0000321 "prosthetic right upper first secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000321 "prosthetic right upper first secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000321 obo:OHD_0000302)
 
 # Class: obo:OHD_0000322 (prosthetic right upper secondary canine tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000322 "A prosthetic tooth that is used a substitute for a right upper secondary canine tooth (tooth 6).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000322 "A prosthetic tooth that is used a substitute for a right upper secondary canine tooth (tooth 6)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000322 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000322 "prosthetic tooth 6")
-AnnotationAssertion(rdfs:label obo:OHD_0000322 "prosthetic right upper secondary canine tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000322 "prosthetic right upper secondary canine tooth"@en)
 SubClassOf(obo:OHD_0000322 obo:OHD_0000302)
 
 # Class: obo:OHD_0000323 (prosthetic right upper lateral secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000323 "A prosthetic tooth that is used a substitute for a right upper lateral secondary incisor tooth (tooth 7).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000323 "A prosthetic tooth that is used a substitute for a right upper lateral secondary incisor tooth (tooth 7)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000323 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000323 "prosthetic tooth 7")
-AnnotationAssertion(rdfs:label obo:OHD_0000323 "prosthetic right upper lateral secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000323 "prosthetic right upper lateral secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000323 obo:OHD_0000302)
 
 # Class: obo:OHD_0000324 (prosthetic right upper central secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000324 "A prosthetic tooth that is used a substitute for a right upper central secondary incisor tooth (tooth 8).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000324 "A prosthetic tooth that is used a substitute for a right upper central secondary incisor tooth (tooth 8)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000324 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000324 "prosthetic tooth 8")
-AnnotationAssertion(rdfs:label obo:OHD_0000324 "prosthetic right upper central secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000324 "prosthetic right upper central secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000324 obo:OHD_0000302)
 
 # Class: obo:OHD_0000325 (prosthetic left upper central secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000325 "A prosthetic tooth that is used a substitute for a left upper central secondary incisor tooth (tooth 9).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000325 "A prosthetic tooth that is used a substitute for a left upper central secondary incisor tooth (tooth 9)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000325 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000325 "prosthetic tooth 9")
-AnnotationAssertion(rdfs:label obo:OHD_0000325 "prosthetic left upper central secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000325 "prosthetic left upper central secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000325 obo:OHD_0000302)
 
 # Class: obo:OHD_0000326 (prosthetic left upper lateral secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000326 "A prosthetic tooth that is used a substitute for a left upper lateral secondary incisor tooth (tooth 10).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000326 "A prosthetic tooth that is used a substitute for a left upper lateral secondary incisor tooth (tooth 10)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000326 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000326 "prosthetic tooth 10")
-AnnotationAssertion(rdfs:label obo:OHD_0000326 "prosthetic left upper lateral secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000326 "prosthetic left upper lateral secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000326 obo:OHD_0000302)
 
 # Class: obo:OHD_0000327 (prosthetic left upper secondary canine tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000327 "A prosthetic tooth that is used a substitute for a left upper secondary canine tooth (tooth 11).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000327 "A prosthetic tooth that is used a substitute for a left upper secondary canine tooth (tooth 11)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000327 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000327 "prosthetic tooth 11")
-AnnotationAssertion(rdfs:label obo:OHD_0000327 "prosthetic left upper secondary canine tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000327 "prosthetic left upper secondary canine tooth"@en)
 SubClassOf(obo:OHD_0000327 obo:OHD_0000302)
 
 # Class: obo:OHD_0000328 (prosthetic left upper first secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000328 "A prosthetic tooth that is used a substitute for a left upper first secondary premolar tooth (tooth 12).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000328 "A prosthetic tooth that is used a substitute for a left upper first secondary premolar tooth (tooth 12)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000328 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000328 "prosthetic tooth 12")
-AnnotationAssertion(rdfs:label obo:OHD_0000328 "prosthetic left upper first secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000328 "prosthetic left upper first secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000328 obo:OHD_0000302)
 
 # Class: obo:OHD_0000329 (prosthetic left upper second secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000329 "A prosthetic tooth that is used a substitute for a left upper second secondary premolar tooth (tooth 13).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000329 "A prosthetic tooth that is used a substitute for a left upper second secondary premolar tooth (tooth 13)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000329 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000329 "prosthetic tooth 13")
-AnnotationAssertion(rdfs:label obo:OHD_0000329 "prosthetic left upper second secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000329 "prosthetic left upper second secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000329 obo:OHD_0000302)
 
 # Class: obo:OHD_0000330 (prosthetic left upper first secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000330 "A prosthetic tooth that is used a substitute for a left upper first secondary molar tooth (tooth 14).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000330 "A prosthetic tooth that is used a substitute for a left upper first secondary molar tooth (tooth 14)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000330 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000330 "prosthetic tooth 14")
-AnnotationAssertion(rdfs:label obo:OHD_0000330 "prosthetic left upper first secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000330 "prosthetic left upper first secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000330 obo:OHD_0000302)
 
 # Class: obo:OHD_0000331 (prosthetic left upper second secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000331 "A prosthetic tooth that is used a substitute for a left upper second secondary molar tooth (tooth 15).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000331 "A prosthetic tooth that is used a substitute for a left upper second secondary molar tooth (tooth 15)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000331 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000331 "prosthetic tooth 15")
-AnnotationAssertion(rdfs:label obo:OHD_0000331 "prosthetic left upper second secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000331 "prosthetic left upper second secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000331 obo:OHD_0000302)
 
 # Class: obo:OHD_0000332 (prosthetic left upper third secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000332 "A prosthetic tooth that is used a substitute for a left upper third secondary molar tooth (tooth 16).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000332 "A prosthetic tooth that is used a substitute for a left upper third secondary molar tooth (tooth 16)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000332 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000332 "prothetic tooth 16")
-AnnotationAssertion(rdfs:label obo:OHD_0000332 "prosthetic left upper third secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000332 "prosthetic left upper third secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000332 obo:OHD_0000302)
 
 # Class: obo:OHD_0000333 (prosthetic left lower third secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000333 "A prosthetic tooth that is used a substitute for a left lower third secondary molar tooth (tooth 17).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000333 "A prosthetic tooth that is used a substitute for a left lower third secondary molar tooth (tooth 17)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000333 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000333 "prosthetic tooth 17")
-AnnotationAssertion(rdfs:label obo:OHD_0000333 "prosthetic left lower third secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000333 "prosthetic left lower third secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000333 obo:OHD_0000302)
 
 # Class: obo:OHD_0000334 (prosthetic left lower second secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000334 "A prosthetic tooth that is used a substitute for a left lower second secondary molar tooth (tooth 18).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000334 "A prosthetic tooth that is used a substitute for a left lower second secondary molar tooth (tooth 18)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000334 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000334 "prosthetic tooth 18")
-AnnotationAssertion(rdfs:label obo:OHD_0000334 "prosthetic left lower second secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000334 "prosthetic left lower second secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000334 obo:OHD_0000302)
 
 # Class: obo:OHD_0000335 (prosthetic left lower first secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000335 "A prosthetic tooth that is used a substitute for a left lower first secondary molar tooth (tooth 19).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000335 "A prosthetic tooth that is used a substitute for a left lower first secondary molar tooth (tooth 19)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000335 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000335 "prosthetic tooth 19")
-AnnotationAssertion(rdfs:label obo:OHD_0000335 "prosthetic left lower first secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000335 "prosthetic left lower first secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000335 obo:OHD_0000302)
 
 # Class: obo:OHD_0000336 (prosthetic left lower second secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000336 "A prosthetic tooth that is used a substitute for a left lower second secondary premolar tooth (tooth 20).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000336 "A prosthetic tooth that is used a substitute for a left lower second secondary premolar tooth (tooth 20)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000336 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000336 "prosthetic tooth 20")
-AnnotationAssertion(rdfs:label obo:OHD_0000336 "prosthetic left lower second secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000336 "prosthetic left lower second secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000336 obo:OHD_0000302)
 
 # Class: obo:OHD_0000337 (prosthetic left lower first secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000337 "A prosthetic tooth that is used a substitute for a left lower first secondary premolar tooth (tooth 21).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000337 "A prosthetic tooth that is used a substitute for a left lower first secondary premolar tooth (tooth 21)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000337 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000337 "prosthetic tooth 21")
-AnnotationAssertion(rdfs:label obo:OHD_0000337 "prosthetic left lower first secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000337 "prosthetic left lower first secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000337 obo:OHD_0000302)
 
 # Class: obo:OHD_0000338 (prosthetic left lower secondary canine tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000338 "A prosthetic tooth that is used a substitute for a left lower secondary canine tooth (tooth 22).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000338 "A prosthetic tooth that is used a substitute for a left lower secondary canine tooth (tooth 22)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000338 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000338 "prosthetic tooth 22")
-AnnotationAssertion(rdfs:label obo:OHD_0000338 "prosthetic left lower secondary canine tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000338 "prosthetic left lower secondary canine tooth"@en)
 SubClassOf(obo:OHD_0000338 obo:OHD_0000302)
 
 # Class: obo:OHD_0000339 (prosthetic left lower lateral secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000339 "A prosthetic tooth that is used a substitute for a left lower lateral secondary incisor tooth (tooth 23).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000339 "A prosthetic tooth that is used a substitute for a left lower lateral secondary incisor tooth (tooth 23)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000339 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000339 "prosthetic tooth 23")
-AnnotationAssertion(rdfs:label obo:OHD_0000339 "prosthetic left lower lateral secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000339 "prosthetic left lower lateral secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000339 obo:OHD_0000302)
 
 # Class: obo:OHD_0000340 (prosthetic left lower central secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000340 "A prosthetic tooth that is used a substitute for a left lower central secondary incisor tooth (tooth 24).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000340 "A prosthetic tooth that is used a substitute for a left lower central secondary incisor tooth (tooth 24)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000340 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000340 "prosthetic tooth 24")
-AnnotationAssertion(rdfs:label obo:OHD_0000340 "prosthetic left lower central secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000340 "prosthetic left lower central secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000340 obo:OHD_0000302)
 
 # Class: obo:OHD_0000341 (prosthetic right lower central secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000341 "A prosthetic tooth that is used a substitute for a right lower central secondary incisor tooth (tooth 25).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000341 "A prosthetic tooth that is used a substitute for a right lower central secondary incisor tooth (tooth 25)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000341 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000341 "prosthetic tooth 25")
-AnnotationAssertion(rdfs:label obo:OHD_0000341 "prosthetic right lower central secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000341 "prosthetic right lower central secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000341 obo:OHD_0000302)
 
 # Class: obo:OHD_0000342 (prosthetic right lower lateral secondary incisor tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000342 "A prosthetic tooth that is used a substitute for a right lower lateral secondary incisor tooth (tooth 26).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000342 "A prosthetic tooth that is used a substitute for a right lower lateral secondary incisor tooth (tooth 26)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000342 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000342 "prosthetic tooth 26")
-AnnotationAssertion(rdfs:label obo:OHD_0000342 "prosthetic right lower lateral secondary incisor tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000342 "prosthetic right lower lateral secondary incisor tooth"@en)
 SubClassOf(obo:OHD_0000342 obo:OHD_0000302)
 
 # Class: obo:OHD_0000343 (prosthetic right lower secondary canine tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000343 "A prosthetic tooth that is used a substitute for a right lower secondary canine tooth (tooth 27).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000343 "A prosthetic tooth that is used a substitute for a right lower secondary canine tooth (tooth 27)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000343 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000343 "prosthetic tooth 27")
-AnnotationAssertion(rdfs:label obo:OHD_0000343 "prosthetic right lower secondary canine tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000343 "prosthetic right lower secondary canine tooth"@en)
 SubClassOf(obo:OHD_0000343 obo:OHD_0000302)
 
 # Class: obo:OHD_0000344 (prosthetic right lower first secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000344 "A prosthetic tooth that is used a substitute for a right lower first secondary premolar tooth (tooth 28).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000344 "A prosthetic tooth that is used a substitute for a right lower first secondary premolar tooth (tooth 28)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000344 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000344 "prosthetic tooth 28")
-AnnotationAssertion(rdfs:label obo:OHD_0000344 "prosthetic right lower first secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000344 "prosthetic right lower first secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000344 obo:OHD_0000302)
 
 # Class: obo:OHD_0000345 (prosthetic right lower second secondary premolar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000345 "A prosthetic tooth that is used a substitute for a right lower second secondary premolar tooth (tooth 29).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000345 "A prosthetic tooth that is used a substitute for a right lower second secondary premolar tooth (tooth 29)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000345 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000345 "prosthetic tooth 29")
-AnnotationAssertion(rdfs:label obo:OHD_0000345 "prosthetic right lower second secondary premolar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000345 "prosthetic right lower second secondary premolar tooth"@en)
 SubClassOf(obo:OHD_0000345 obo:OHD_0000302)
 
 # Class: obo:OHD_0000346 (prosthetic right lower first secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000346 "A prosthetic tooth that is used a substitute for a right lower first secondary molar tooth (tooth 30).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000346 "A prosthetic tooth that is used a substitute for a right lower first secondary molar tooth (tooth 30)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000346 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000346 "prosthetic tooth 30")
-AnnotationAssertion(rdfs:label obo:OHD_0000346 "prosthetic right lower first secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000346 "prosthetic right lower first secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000346 obo:OHD_0000302)
 
 # Class: obo:OHD_0000347 (prosthetic right lower second secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000347 "A prosthetic tooth that is used a substitute for a right lower second secondary molar tooth (tooth 31).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000347 "A prosthetic tooth that is used a substitute for a right lower second secondary molar tooth (tooth 31)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000347 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000347 "prosthetic tooth 31")
-AnnotationAssertion(rdfs:label obo:OHD_0000347 "prosthetic right lower second secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000347 "prosthetic right lower second secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000347 obo:OHD_0000302)
 
 # Class: obo:OHD_0000348 (prosthetic right lower third secondary molar tooth)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000348 "A prosthetic tooth that is used a substitute for a right lower third secondary molar tooth (tooth 32).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000348 "A prosthetic tooth that is used a substitute for a right lower third secondary molar tooth (tooth 32)."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000348 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000118 obo:OHD_0000348 "prosthetic tooth 32")
-AnnotationAssertion(rdfs:label obo:OHD_0000348 "prosthetic right lower third secondary molar tooth")
+AnnotationAssertion(rdfs:label obo:OHD_0000348 "prosthetic right lower third secondary molar tooth"@en)
 SubClassOf(obo:OHD_0000348 obo:OHD_0000302)
 
 # Class: obo:OHD_0000349 (dental material combination process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000349 "A material combination in which two or more dental restoration materials are combined.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000349 "A material combination in which two or more dental restoration materials are combined."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000349 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000349 "dental material combination process")
+AnnotationAssertion(rdfs:label obo:OHD_0000349 "dental material combination process"@en)
 SubClassOf(obo:OHD_0000349 obo:OBI_0000652)
 
 # Class: obo:OHD_0000350 (temporary prosthetic role)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000350 "provisional crown")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000350 "A prosthetic role that is borne by a material entity which is serves as a temporary replacement for some body part in order to allow adequate time for healing or completion of other procedures.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000350 "A prosthetic role that is borne by a material entity which is serves as a temporary replacement for some body part in order to allow adequate time for healing or completion of other procedures."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000350 "Bill Duncan")
-AnnotationAssertion(rdfs:label obo:OHD_0000350 "temporary prosthetic role")
+AnnotationAssertion(rdfs:label obo:OHD_0000350 "temporary prosthetic role"@en)
 SubClassOf(obo:OHD_0000350 obo:OHD_0000314)
 
 # Class: obo:OHD_0000351 (dental implant retainer attachement procedure for porcelain fused to metal fixed partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000351 "A dental implant retainer attachement procedure for fixed partial denture in which the retainer being attached to the implant body is to be used as a retainer for a porcelain fused to metal fixed partial denture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000351 "A dental implant retainer attachement procedure for fixed partial denture in which the retainer being attached to the implant body is to be used as a retainer for a porcelain fused to metal fixed partial denture."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000351 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000351 "2022-12-06T04:42:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000351 "dental implant retainer attachement procedure for porcelain fused to metal fixed partial denture"@en)
@@ -4821,7 +4821,7 @@ SubClassOf(obo:OHD_0000351 obo:OHD_0000300)
 
 # Class: obo:OHD_0000352 (ceramic fixed partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000352 "A fixed partial denture constructed out of ceramic.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000352 "A fixed partial denture constructed out of ceramic."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000352 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000352 "2022-12-06T03:39:55Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000352 "ceramic fixed partial denture"@en)
@@ -4829,7 +4829,7 @@ SubClassOf(obo:OHD_0000352 obo:OHD_0000312)
 
 # Class: obo:OHD_0000353 (porcelain fused to metal fixed partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000353 "A fixed partial denture constructed out of porcelain fused to metal.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000353 "A fixed partial denture constructed out of porcelain fused to metal."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000353 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000353 "2022-12-06T03:43:52Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000353 "porcelain fused to metal fixed partial denture"@en)
@@ -4837,7 +4837,7 @@ SubClassOf(obo:OHD_0000353 obo:OHD_0000312)
 
 # Class: obo:OHD_0000354 (ceramic implant supported partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000354 "An implant supported fixed partial denture constructed out of ceramic.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000354 "An implant supported fixed partial denture constructed out of ceramic."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000354 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000354 "2022-12-06T03:42:00Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000354 "ceramic implant supported partial denture"@en)
@@ -4845,7 +4845,7 @@ SubClassOf(obo:OHD_0000354 obo:OHD_0000251)
 
 # Class: obo:OHD_0000355 (porcelain fused to metal implant supported partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000355 "An implant supported fixed partial denture constructed out of porcelain fused to metal.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000355 "An implant supported fixed partial denture constructed out of porcelain fused to metal."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000355 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000355 "2022-12-06T03:42:38Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000355 "porcelain fused to metal implant supported partial denture"@en)
@@ -4853,7 +4853,7 @@ SubClassOf(obo:OHD_0000355 obo:OHD_0000251)
 
 # Class: obo:OHD_0000356 (porcelain fused to metal tooth supported partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000356 "A tooth supported fixed partial denture constructed out of porcelain fused to metal.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000356 "A tooth supported fixed partial denture constructed out of porcelain fused to metal."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000356 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000356 "2022-12-06T03:51:56Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000356 "porcelain fused to metal tooth supported partial denture"@en)
@@ -4861,7 +4861,7 @@ SubClassOf(obo:OHD_0000356 obo:OHD_0000311)
 
 # Class: obo:OHD_0000357 (ceramic tooth supported partial denture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000357 "A tooth supported fixed partial denture constructed out of ceramic.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000357 "A tooth supported fixed partial denture constructed out of ceramic."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000357 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000357 "2022-12-06T03:51:23Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000357 "ceramic tooth supported partial denture"@en)
@@ -4869,7 +4869,7 @@ SubClassOf(obo:OHD_0000357 obo:OHD_0000311)
 
 # Class: obo:OHD_0000358 (dental implant fixed partial denture retainer)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000358 "A dental implant abutment that serves as a retainer for a fixed partial denture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000358 "A dental implant abutment that serves as a retainer for a fixed partial denture."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000358 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000358 "2022-12-06T04:22:08Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000358 "dental implant fixed partial denture retainer"@en)
@@ -4877,7 +4877,7 @@ SubClassOf(obo:OHD_0000358 obo:OHD_0000279)
 
 # Class: obo:OHD_0000359 (high noble metal implant crown)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000359 "A dental implant crown constructed out of high noble metal.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000359 "A dental implant crown constructed out of high noble metal."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000359 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000359 "2022-12-06T04:30:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000359 "high noble metal implant crown"@en)
@@ -4885,7 +4885,7 @@ SubClassOf(obo:OHD_0000359 obo:OHD_0000280)
 
 # Class: obo:OHD_0000361 (coronal caries finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000361 "A caries finding in which the caries lesion is found to be in the tooth's crown.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000361 "A caries finding in which the caries lesion is found to be in the tooth's crown."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000361 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000361 "2017-11-09T22:29:25Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000361 "coronal caries finding"@en)
@@ -4893,7 +4893,7 @@ SubClassOf(obo:OHD_0000361 obo:OHD_0000024)
 
 # Class: obo:OHD_0000362 (tooth root caries finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000362 "A caries finding in which the caries lesion is found to be in the tooth's root.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000362 "A caries finding in which the caries lesion is found to be in the tooth's root."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000362 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000362 "2017-11-09T22:30:09Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000362 "tooth root caries finding"@en)
@@ -4901,294 +4901,294 @@ SubClassOf(obo:OHD_0000362 obo:OHD_0000024)
 
 # Class: obo:OHD_0000364 (secondary dentition missing tooth 1)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000364 "A secondary dentition that is missing tooth 1.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000364 "A secondary dentition that is missing tooth 1."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000364 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000364 "2017-11-10T03:42:18Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000364 "secondary dentition missing tooth 1")
+AnnotationAssertion(rdfs:label obo:OHD_0000364 "secondary dentition missing tooth 1"@en)
 EquivalentClasses(obo:OHD_0000364 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "1")))
 SubClassOf(obo:OHD_0000364 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000365 (secondary dentition missing tooth 2)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000365 "A secondary dentition that is missing tooth 2.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000365 "A secondary dentition that is missing tooth 2."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000365 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000365 "2017-11-10T03:49:27Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000365 "secondary dentition missing tooth 2")
+AnnotationAssertion(rdfs:label obo:OHD_0000365 "secondary dentition missing tooth 2"@en)
 EquivalentClasses(obo:OHD_0000365 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "2")))
 SubClassOf(obo:OHD_0000365 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000366 (secondary dentition missing tooth 3)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000366 "A secondary dentition that is missing tooth 3.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000366 "A secondary dentition that is missing tooth 3."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000366 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000366 "2017-11-10T03:49:34Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000366 "secondary dentition missing tooth 3")
+AnnotationAssertion(rdfs:label obo:OHD_0000366 "secondary dentition missing tooth 3"@en)
 EquivalentClasses(obo:OHD_0000366 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "3")))
 SubClassOf(obo:OHD_0000366 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000367 (secondary dentition missing tooth 4)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000367 "A secondary dentition that is missing tooth 4.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000367 "A secondary dentition that is missing tooth 4."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000367 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000367 "2017-11-10T03:49:39Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000367 "secondary dentition missing tooth 4")
+AnnotationAssertion(rdfs:label obo:OHD_0000367 "secondary dentition missing tooth 4"@en)
 EquivalentClasses(obo:OHD_0000367 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "4")))
 SubClassOf(obo:OHD_0000367 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000368 (secondary dentition missing tooth 5)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000368 "A secondary dentition that is missing tooth 5.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000368 "A secondary dentition that is missing tooth 5."@en)
 AnnotationAssertion(dcterms:created obo:OHD_0000368 "2017-11-10T03:49:48Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000368 "secondary dentition missing tooth 5")
+AnnotationAssertion(rdfs:label obo:OHD_0000368 "secondary dentition missing tooth 5"@en)
 EquivalentClasses(obo:OHD_0000368 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "5")))
 SubClassOf(obo:OHD_0000368 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000369 (secondary dentition missing tooth 6)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000369 "A secondary dentition that is missing tooth 6.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000369 "A secondary dentition that is missing tooth 6."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000369 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000369 "2017-11-10T03:49:54Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000369 "secondary dentition missing tooth 6")
+AnnotationAssertion(rdfs:label obo:OHD_0000369 "secondary dentition missing tooth 6"@en)
 EquivalentClasses(obo:OHD_0000369 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "6")))
 SubClassOf(obo:OHD_0000369 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000370 (secondary dentition missing tooth 7)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000370 "A secondary dentition that is missing tooth 7.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000370 "A secondary dentition that is missing tooth 7."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000370 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000370 "2017-11-10T03:50:01Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000370 "secondary dentition missing tooth 7")
+AnnotationAssertion(rdfs:label obo:OHD_0000370 "secondary dentition missing tooth 7"@en)
 EquivalentClasses(obo:OHD_0000370 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "7")))
 SubClassOf(obo:OHD_0000370 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000371 (secondary dentition missing tooth 8)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000371 "A secondary dentition that is missing tooth 8.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000371 "A secondary dentition that is missing tooth 8."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000371 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000371 "2017-11-10T03:50:08Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000371 "secondary dentition missing tooth 8")
+AnnotationAssertion(rdfs:label obo:OHD_0000371 "secondary dentition missing tooth 8"@en)
 EquivalentClasses(obo:OHD_0000371 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "8")))
 SubClassOf(obo:OHD_0000371 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000372 (secondary dentition missing tooth 9)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000372 "A secondary dentition that is missing tooth 9.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000372 "A secondary dentition that is missing tooth 9."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000372 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000372 "2017-11-10T03:50:29Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000372 "secondary dentition missing tooth 9")
+AnnotationAssertion(rdfs:label obo:OHD_0000372 "secondary dentition missing tooth 9"@en)
 EquivalentClasses(obo:OHD_0000372 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "9")))
 SubClassOf(obo:OHD_0000372 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000373 (secondary dentition missing tooth 10)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000373 "A secondary dentition that is missing tooth 10.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000373 "A secondary dentition that is missing tooth 10."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000373 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000373 "2017-11-10T03:50:36Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000373 "secondary dentition missing tooth 10")
+AnnotationAssertion(rdfs:label obo:OHD_0000373 "secondary dentition missing tooth 10"@en)
 EquivalentClasses(obo:OHD_0000373 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "10")))
 SubClassOf(obo:OHD_0000373 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000374 (secondary dentition missing tooth 11)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000374 "A secondary dentition that is missing tooth 11.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000374 "A secondary dentition that is missing tooth 11."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000374 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000374 "2017-11-10T03:50:44Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000374 "secondary dentition missing tooth 11")
+AnnotationAssertion(rdfs:label obo:OHD_0000374 "secondary dentition missing tooth 11"@en)
 EquivalentClasses(obo:OHD_0000374 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "11")))
 SubClassOf(obo:OHD_0000374 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000375 (secondary dentition missing tooth 12)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000375 "A secondary dentition that is missing tooth 12.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000375 "A secondary dentition that is missing tooth 12."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000375 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000375 "2017-11-10T03:50:49Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000375 "secondary dentition missing tooth 12")
+AnnotationAssertion(rdfs:label obo:OHD_0000375 "secondary dentition missing tooth 12"@en)
 EquivalentClasses(obo:OHD_0000375 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "12")))
 SubClassOf(obo:OHD_0000375 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000376 (secondary dentition missing tooth 13)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000376 "A secondary dentition that is missing tooth 13.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000376 "A secondary dentition that is missing tooth 13."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000376 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000376 "2017-11-10T03:50:55Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000376 "secondary dentition missing tooth 13")
+AnnotationAssertion(rdfs:label obo:OHD_0000376 "secondary dentition missing tooth 13"@en)
 EquivalentClasses(obo:OHD_0000376 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "13")))
 SubClassOf(obo:OHD_0000376 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000377 (secondary dentition missing tooth 14)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000377 "A secondary dentition that is missing tooth 14.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000377 "A secondary dentition that is missing tooth 14."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000377 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000377 "2017-11-10T03:51:02Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000377 "secondary dentition missing tooth 14")
+AnnotationAssertion(rdfs:label obo:OHD_0000377 "secondary dentition missing tooth 14"@en)
 EquivalentClasses(obo:OHD_0000377 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "14")))
 SubClassOf(obo:OHD_0000377 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000378 (secondary dentition missing tooth 15)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000378 "A secondary dentition that is missing tooth 15.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000378 "A secondary dentition that is missing tooth 15."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000378 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000378 "2017-11-10T03:51:11Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000378 "secondary dentition missing tooth 15")
+AnnotationAssertion(rdfs:label obo:OHD_0000378 "secondary dentition missing tooth 15"@en)
 EquivalentClasses(obo:OHD_0000378 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "15")))
 SubClassOf(obo:OHD_0000378 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000379 (secondary dentition missing tooth 16)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000379 "A secondary dentition that is missing tooth 16,")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000379 "A secondary dentition that is missing tooth 16,"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000379 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000379 "2017-11-10T03:51:17Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000379 "secondary dentition missing tooth 16")
+AnnotationAssertion(rdfs:label obo:OHD_0000379 "secondary dentition missing tooth 16"@en)
 EquivalentClasses(obo:OHD_0000379 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "16")))
 SubClassOf(obo:OHD_0000379 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000380 (secondary dentition missing tooth 17)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000380 "A secondary dentition that is missing tooth 17.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000380 "A secondary dentition that is missing tooth 17."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000380 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000380 "2017-11-10T03:51:23Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000380 "secondary dentition missing tooth 17")
+AnnotationAssertion(rdfs:label obo:OHD_0000380 "secondary dentition missing tooth 17"@en)
 EquivalentClasses(obo:OHD_0000380 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "17")))
 SubClassOf(obo:OHD_0000380 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000381 (secondary dentition missing tooth 18)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000381 "A secondary dentition that is missing tooth 18.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000381 "A secondary dentition that is missing tooth 18."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000381 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000381 "2017-11-10T03:51:28Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000381 "secondary dentition missing tooth 18")
+AnnotationAssertion(rdfs:label obo:OHD_0000381 "secondary dentition missing tooth 18"@en)
 EquivalentClasses(obo:OHD_0000381 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "18")))
 SubClassOf(obo:OHD_0000381 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000382 (secondary dentition missing tooth 19)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000382 "A secondary dentition that is missing tooth 19.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000382 "A secondary dentition that is missing tooth 19."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000382 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000382 "2017-11-10T03:51:33Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000382 "secondary dentition missing tooth 19")
+AnnotationAssertion(rdfs:label obo:OHD_0000382 "secondary dentition missing tooth 19"@en)
 EquivalentClasses(obo:OHD_0000382 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "19")))
 SubClassOf(obo:OHD_0000382 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000383 (secondary dentition missing tooth 20)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000383 "A secondary dentition that is missing tooth 20.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000383 "A secondary dentition that is missing tooth 20."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000383 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000383 "2017-11-10T03:51:38Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000383 "secondary dentition missing tooth 20")
+AnnotationAssertion(rdfs:label obo:OHD_0000383 "secondary dentition missing tooth 20"@en)
 EquivalentClasses(obo:OHD_0000383 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "20")))
 SubClassOf(obo:OHD_0000383 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000384 (secondary dentition missing tooth 21)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000384 "A secondary dentition that is missing tooth 21.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000384 "A secondary dentition that is missing tooth 21."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000384 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000384 "2017-11-10T03:51:45Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000384 "secondary dentition missing tooth 21")
+AnnotationAssertion(rdfs:label obo:OHD_0000384 "secondary dentition missing tooth 21"@en)
 EquivalentClasses(obo:OHD_0000384 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "21")))
 SubClassOf(obo:OHD_0000384 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000385 (secondary dentition missing tooth 22)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000385 "A secondary dentition that is missing tooth 22.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000385 "A secondary dentition that is missing tooth 22."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000385 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000385 "2017-11-10T03:52:02Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000385 "secondary dentition missing tooth 22")
+AnnotationAssertion(rdfs:label obo:OHD_0000385 "secondary dentition missing tooth 22"@en)
 EquivalentClasses(obo:OHD_0000385 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "22")))
 SubClassOf(obo:OHD_0000385 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000386 (secondary dentition missing tooth 23)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000386 "A secondary dentition that is missing tooth 23.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000386 "A secondary dentition that is missing tooth 23."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000386 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000386 "2017-11-10T03:52:06Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000386 "secondary dentition missing tooth 23")
+AnnotationAssertion(rdfs:label obo:OHD_0000386 "secondary dentition missing tooth 23"@en)
 EquivalentClasses(obo:OHD_0000386 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "23")))
 SubClassOf(obo:OHD_0000386 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000387 (secondary dentition missing tooth 24)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000387 "A secondary dentition that is missing tooth 24.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000387 "A secondary dentition that is missing tooth 24."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000387 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000387 "2017-11-10T03:52:13Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000387 "secondary dentition missing tooth 24")
+AnnotationAssertion(rdfs:label obo:OHD_0000387 "secondary dentition missing tooth 24"@en)
 EquivalentClasses(obo:OHD_0000387 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "24")))
 SubClassOf(obo:OHD_0000387 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000388 (secondary dentition missing tooth 25)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000388 "A secondary dentition that is missing tooth 25.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000388 "A secondary dentition that is missing tooth 25."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000388 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000388 "2017-11-10T03:52:16Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000388 "secondary dentition missing tooth 25")
+AnnotationAssertion(rdfs:label obo:OHD_0000388 "secondary dentition missing tooth 25"@en)
 EquivalentClasses(obo:OHD_0000388 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "25")))
 SubClassOf(obo:OHD_0000388 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000389 (secondary dentition missing tooth 26)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000389 "A secondary dentition that is missing tooth 26.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000389 "A secondary dentition that is missing tooth 26."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000389 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000389 "2017-11-10T03:52:20Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000389 "secondary dentition missing tooth 26")
+AnnotationAssertion(rdfs:label obo:OHD_0000389 "secondary dentition missing tooth 26"@en)
 EquivalentClasses(obo:OHD_0000389 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "26")))
 SubClassOf(obo:OHD_0000389 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000390 (secondary dentition missing tooth 27)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000390 "A secondary dentition that is missing tooth 27.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000390 "A secondary dentition that is missing tooth 27."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000390 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000390 "2017-11-10T03:52:25Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000390 "secondary dentition missing tooth 27")
+AnnotationAssertion(rdfs:label obo:OHD_0000390 "secondary dentition missing tooth 27"@en)
 EquivalentClasses(obo:OHD_0000390 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "27")))
 SubClassOf(obo:OHD_0000390 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000391 (secondary dentition missing tooth 28)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000391 "A secondary dentition that is missing tooth 28.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000391 "A secondary dentition that is missing tooth 28."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000391 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000391 "2017-11-10T03:52:36Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000391 "secondary dentition missing tooth 28")
+AnnotationAssertion(rdfs:label obo:OHD_0000391 "secondary dentition missing tooth 28"@en)
 EquivalentClasses(obo:OHD_0000391 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "28")))
 SubClassOf(obo:OHD_0000391 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000392 (secondary dentition missing tooth 29)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000392 "A secondary dentition that is missing tooth 29.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000392 "A secondary dentition that is missing tooth 29."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000392 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000392 "2017-11-10T03:52:40Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000392 "secondary dentition missing tooth 29")
+AnnotationAssertion(rdfs:label obo:OHD_0000392 "secondary dentition missing tooth 29"@en)
 EquivalentClasses(obo:OHD_0000392 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "29")))
 SubClassOf(obo:OHD_0000392 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000393 (secondary dentition missing tooth 30)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000393 "A secondary dentition that is missing tooth 30.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000393 "A secondary dentition that is missing tooth 30."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000393 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000393 "2017-11-10T03:52:48Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000393 "secondary dentition missing tooth 30")
+AnnotationAssertion(rdfs:label obo:OHD_0000393 "secondary dentition missing tooth 30"@en)
 EquivalentClasses(obo:OHD_0000393 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "30")))
 SubClassOf(obo:OHD_0000393 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000394 (secondary dentition missing tooth 31)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000394 "A secondary dentition that is missing tooth 31.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000394 "A secondary dentition that is missing tooth 31."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000394 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000394 "2017-11-10T03:52:54Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000394 "secondary dentition missing tooth 31")
+AnnotationAssertion(rdfs:label obo:OHD_0000394 "secondary dentition missing tooth 31"@en)
 EquivalentClasses(obo:OHD_0000394 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "31")))
 SubClassOf(obo:OHD_0000394 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000395 (secondary dentition missing tooth 32)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000395 "A secondary dentition that is missing tooth 32.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000395 "A secondary dentition that is missing tooth 32."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000395 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000395 "2017-11-10T03:52:59Z")
-AnnotationAssertion(rdfs:label obo:OHD_0000395 "secondary dentition missing tooth 32")
+AnnotationAssertion(rdfs:label obo:OHD_0000395 "secondary dentition missing tooth 32"@en)
 EquivalentClasses(obo:OHD_0000395 ObjectIntersectionOf(obo:UBERON_0007774 DataHasValue(obo:OHD_0000234 "32")))
 SubClassOf(obo:OHD_0000395 obo:UBERON_0007774)
 
 # Class: obo:OHD_0000396 (endodontic procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000396 "A dental finding procedure that an endodontic procedure was performed on the patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000396 "A dental finding procedure that an endodontic procedure was performed on the patient."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000396 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000396 "2017-11-21T03:27:27Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000396 "endodontic procedure finding"@en)
@@ -5197,7 +5197,7 @@ SubClassOf(obo:OHD_0000396 obo:OHD_0000221)
 
 # Class: obo:OHD_0000397 (prosthodontics procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000397 "A dental finding procedure that procedure a prosthodontics procedure was performed on the patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000397 "A dental finding procedure that procedure a prosthodontics procedure was performed on the patient."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000397 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000397 "2017-11-21T03:27:44Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000397 "prosthodontics procedure finding"@en)
@@ -5206,7 +5206,7 @@ SubClassOf(obo:OHD_0000397 obo:OHD_0000221)
 
 # Class: obo:OHD_0000398 (surgical dental procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000398 "A dental finding procedure that a surgical dental procedure was performed on the patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000398 "A dental finding procedure that a surgical dental procedure was performed on the patient."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000398 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000398 "2017-11-21T03:28:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000398 "surgical dental procedure finding"@en)
@@ -5215,7 +5215,7 @@ SubClassOf(obo:OHD_0000398 obo:OHD_0000221)
 
 # Class: obo:OHD_0000399 (tooth restoration procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000399 "A dental finding procedure that tooth restoration procedure was performed on the patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000399 "A dental finding procedure that tooth restoration procedure was performed on the patient."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000399 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000399 "2017-11-21T03:28:33Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000399 "tooth restoration procedure finding"@en)
@@ -5224,7 +5224,7 @@ SubClassOf(obo:OHD_0000399 obo:OHD_0000221)
 
 # Class: obo:OHD_0000400 (crown restoration procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000400 "A dental finding procedure that a crown restoration procedure was performed on the patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000400 "A dental finding procedure that a crown restoration procedure was performed on the patient."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000400 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000400 "2017-11-21T03:28:47Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000400 "crown restoration procedure finding"@en)
@@ -5233,7 +5233,7 @@ SubClassOf(obo:OHD_0000400 obo:OHD_0000399)
 
 # Class: obo:OHD_0000401 (intracoronal restoration procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000401 "A dental finding procedure that an intracoronal restoration procedure was performed on the patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000401 "A dental finding procedure that an intracoronal restoration procedure was performed on the patient."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000401 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000401 "2017-11-21T03:29:24Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000401 "intracoronal restoration procedure finding"@en)
@@ -5242,7 +5242,7 @@ SubClassOf(obo:OHD_0000401 obo:OHD_0000399)
 
 # Class: obo:OHD_0000402 (veneer restoration procedure finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000402 "A dental finding procedure that a veneer restoration procedure was performed on the patient.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000402 "A dental finding procedure that a veneer restoration procedure was performed on the patient."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000402 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000402 "2017-11-21T03:29:54Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000402 "veneer restoration procedure finding"@en)
@@ -5251,7 +5251,7 @@ SubClassOf(obo:OHD_0000402 obo:OHD_0000399)
 
 # Class: obo:OHD_0000403 (oral evaluation finding)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000403 "A dental finding that is about an oral evaluation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000403 "A dental finding that is about an oral evaluation."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000403 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> obo:OHD_0000403 "2017-11-21T03:30:30Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000403 "oral evaluation finding"@en)
@@ -5260,7 +5260,7 @@ SubClassOf(obo:OHD_0000403 obo:OHD_0000010)
 
 # Class: obo:OHD_0000404 (mouth disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000404 "A disease that is a characteristic of a mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000404 "A disease that is a characteristic of a mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000404 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000404 "2025-01-17T19:58:44Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000404 "mouth disease"@en)
@@ -5287,7 +5287,7 @@ SubClassOf(obo:OHD_0000405 obo:OHD_0000043)
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000406 "Mouth breathing")
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000406 "Teeth grinding and clenching")
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000406 "Tongue thrusting")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000406 "A pathological process that involves the mouth and can contribute to some disorder of the head and neck region.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000406 "A pathological process that involves the mouth and can contribute to some disorder of the head and neck region."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000406 "An oral parafunction can include tongue thrusting, mouth breathing, bruxism etc.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000406 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000406 <https://orcid.org/0009-0006-7251-3026>)
@@ -5297,7 +5297,7 @@ SubClassOf(obo:OHD_0000406 obo:OGMS_0000061)
 
 # Class: obo:OHD_0000407 (bruxism)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000407 "A masticatory muscle activity that may result in a disorder within the head and neck region.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000407 "A masticatory muscle activity that may result in a disorder within the head and neck region."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000407 "Involuntary holding of the teeth together and tightening of the jaw muscles or grinding of the teeth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000407 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000407 <https://orcid.org/0009-0006-7251-3026>)
@@ -5385,7 +5385,7 @@ SubClassOf(obo:OHD_0000413 obo:OHD_0000277)
 
 # Class: obo:OHD_0000414 (mouth disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000414 "A disorder that is part of a mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000414 "A disorder that is part of a mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000414 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000414 "2025-01-17T20:08:15Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000414 "mouth disorder"@en)
@@ -5395,7 +5395,7 @@ SubClassOf(obo:OHD_0000414 obo:OGMS_0000045)
 
 # Class: obo:OHD_0000415 (data collection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000415 "An information content entity that contains multiple structured collections of data items.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000415 "An information content entity that contains multiple structured collections of data items."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000415 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000415 "2025-04-13T21:18:24Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000415 "data collection"@en)
@@ -5404,7 +5404,7 @@ SubClassOf(obo:OHD_0000415 obo:IAO_0000030)
 # Class: obo:OHD_0000416 (dataset)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000416 "A set of records in which each record contains a patient's demographic information.")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000416 "A data collection that consists of multiple records or tables which contain records. Although a dataset may contain single record or table, a dataset does not have to be organized as rows and columns and is often saved as a single file.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000416 "A data collection that consists of multiple records or tables which contain records. Although a dataset may contain single record or table, a dataset does not have to be organized as rows and columns and is often saved as a single file."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000416 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000416 "2025-04-13T21:18:30Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000416 "dataset"@en)
@@ -5413,7 +5413,7 @@ SubClassOf(obo:OHD_0000416 obo:OHD_0000415)
 # Class: obo:OHD_0000417 (data record)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000417 "A set of fields that contain information about a patient, such as the patient's first name, last name, and birthdate.")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000417 "A data collection that consists of one or more data fields and structures the data fields as a logical unit.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000417 "A data collection that consists of one or more data fields and structures the data fields as a logical unit."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000417 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000417 "2025-04-13T21:18:38Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000417 "data record"@en)
@@ -5422,7 +5422,7 @@ SubClassOf(obo:OHD_0000417 ObjectSomeValuesFrom(obo:BFO_0000050 obo:OHD_0000416)
 
 # Class: obo:OHD_0000418 (oral microbiome)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000418 "A microbiome that is located in the mouth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000418 "A microbiome that is located in the mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000418 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000418 "oral microbiome"@en)
 EquivalentClasses(obo:OHD_0000418 ObjectIntersectionOf(obo:OHMI_0000003 ObjectSomeValuesFrom(obo:RO_0001025 obo:UBERON_0000165)))
@@ -5430,7 +5430,7 @@ SubClassOf(obo:OHD_0000418 obo:OHMI_0000003)
 
 # Class: obo:OHD_0000419 (data table)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000419 "A data collection in which the data items are organized into rows and columns.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000419 "A data collection in which the data items are organized into rows and columns."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000419 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000419 "2025-04-13T21:19:03Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000419 "data table"@en)
@@ -5438,7 +5438,7 @@ SubClassOf(obo:OHD_0000419 obo:OHD_0000415)
 
 # Class: obo:OHD_0000420 (oral microbial dysbiosis)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "https://pmc.ncbi.nlm.nih.gov/articles/PMC10304820") obo:IAO_0000115 obo:OHD_0000420 "An infectious disorder that is the result of an imbalance or disruption of the microorganisms which normally exist within the mouth.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "https://pmc.ncbi.nlm.nih.gov/articles/PMC10304820") obo:IAO_0000115 obo:OHD_0000420 "An infectious disorder that is the result of an imbalance or disruption of the microorganisms which normally exist within the mouth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000420 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000420 "2025-03-12T22:52:42Z"^^xsd:dateTime)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> obo:OHD_0000420 "oral dysbiosis")
@@ -5496,7 +5496,7 @@ SubClassOf(obo:OHD_0000424 ObjectSomeValuesFrom(obo:IAO_0000136 obo:OHD_0008049)
 # Class: obo:OHD_0000425 (data field)
 
 AnnotationAssertion(obo:IAO_0000112 obo:OHD_0000425 "The birthdate field in a record containing patient information.")
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000425 "A data item that is part of a record and serves as a single unit of information within the record.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000425 "A data item that is part of a record and serves as a single unit of information within the record."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000425 <http://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:created obo:OHD_0000425 "2025-04-13T21:19:13Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0000425 "data field"@en)
@@ -5681,7 +5681,7 @@ SubClassOf(obo:OHD_0000441 obo:OHD_0008010)
 
 # Class: obo:OHD_0000442 (bacterial tooth demineralization process)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "https://www.ncbi.nlm.nih.gov/books/NBK8259") obo:IAO_0000115 obo:OHD_0000442 "A pathological bodily process during which tooth mineral is solubilized by acid produced by certain bacteria that adhere to the tooth surface in bacterial communities known as dental plaque.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "https://www.ncbi.nlm.nih.gov/books/NBK8259") obo:IAO_0000115 obo:OHD_0000442 "A pathological bodily process during which tooth mineral is solubilized by acid produced by certain bacteria that adhere to the tooth surface in bacterial communities known as dental plaque."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000442 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000442 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000442 "2025-03-12T23:20:57Z"^^xsd:dateTime)
@@ -5691,7 +5691,7 @@ SubClassOf(obo:OHD_0000442 ObjectSomeValuesFrom(obo:BFO_0000050 obo:OHD_0000443)
 
 # Class: obo:OHD_0000443 (dental caries disease course)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000443 "An infectious disease course that realizes dental caries.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000443 "An infectious disease course that realizes dental caries."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000443 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000443 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0000443 "2025-03-12T23:02:32Z"^^xsd:dateTime)
@@ -5778,7 +5778,7 @@ SubClassOf(obo:OHD_0000450 ObjectSomeValuesFrom(obo:IAO_0000136 obo:OHD_0008033)
 
 # Class: obo:OHD_0000451 (feeling dental drill vibrations)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000451 "A touching process in which vibrations from a dental drill are perceived.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000451 "A touching process in which vibrations from a dental drill are perceived."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000451 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0000451 <https://orcid.org/0009-0002-7282-0836>)
 AnnotationAssertion(dcterms:created obo:OHD_0000451 "2025-05-14T01:31:15Z"^^xsd:dateTime)
@@ -6002,16 +6002,16 @@ SubClassOf(obo:OHD_0000517 obo:OHD_0000512)
 
 # Class: obo:OHD_0002000 (masticatory muscle activity)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0002000 "A bodily process that involves the masticatory muscles of the head and neck region.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0002000 "A bodily process that involves the masticatory muscles of the head and neck region."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0002000 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0002000 <https://orcid.org/0009-0006-7251-3026>)
 AnnotationAssertion(dcterms:created obo:OHD_0002000 "2023-06-06T21:30:37Z")
-AnnotationAssertion(rdfs:label obo:OHD_0002000 "masticatory muscle activity")
+AnnotationAssertion(rdfs:label obo:OHD_0002000 "masticatory muscle activity"@en)
 SubClassOf(obo:OHD_0002000 obo:OGMS_0000060)
 
 # Class: obo:OHD_0005001 (patient-reported outcome)
 
-AnnotationAssertion(Annotation(obo:IAO_0000119 "https://www.cancer.gov/publications/dictionaries/cancer-terms/def/patient-reported-outcome") Annotation(obo:IAO_0000119 "https://www.pcori.org/sites/default/files/UMD-NORD-Telecon-Two-Patient-Reported-Outcomes.pdf") obo:IAO_0000115 obo:OHD_0005001 "A data item that comes directly from a patient about how they function or feel in relation to the patient's health.  A patient reported outcome can include subjective feelings regarding symptoms, functions in daily life, physical, mental, emotional, spiritual, and social well-being, and satisfaction with the health  care that has been received.")
+AnnotationAssertion(Annotation(obo:IAO_0000119 "https://www.cancer.gov/publications/dictionaries/cancer-terms/def/patient-reported-outcome") Annotation(obo:IAO_0000119 "https://www.pcori.org/sites/default/files/UMD-NORD-Telecon-Two-Patient-Reported-Outcomes.pdf") obo:IAO_0000115 obo:OHD_0005001 "A data item that comes directly from a patient about how they function or feel in relation to the patient's health.  A patient reported outcome can include subjective feelings regarding symptoms, functions in daily life, physical, mental, emotional, spiritual, and social well-being, and satisfaction with the health  care that has been received."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0005001 "This term should be imported from more general ontology like OGMS.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0005001 <https://orcid.org/0000-0001-6378-1703>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005001 <https://orcid.org/0000-0001-6424-4096>)
@@ -6024,7 +6024,7 @@ SubClassOf(obo:OHD_0005001 obo:IAO_0000027)
 
 # Class: obo:OHD_0005002 (patient-reported dental outcome)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005002 "A patient reported outcome regarding a dental condition or treatment.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005002 "A patient reported outcome regarding a dental condition or treatment."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005002 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005002 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005002 <https://orcid.org/0009-0003-7246-1252>)
@@ -6034,7 +6034,7 @@ SubClassOf(obo:OHD_0005002 obo:OHD_0005001)
 
 # Class: obo:OHD_0005003 (patient-reported favorable dental outcome)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005003 "A patient reported dental outcome that is favorable and related to a dental condition or treatment.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005003 "A patient reported dental outcome that is favorable and related to a dental condition or treatment."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005003 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005003 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005003 <https://orcid.org/0009-0003-7246-1252>)
@@ -6044,7 +6044,7 @@ SubClassOf(obo:OHD_0005003 obo:OHD_0000272)
 
 # Class: obo:OHD_0005004 (patient-reported unfavorable dental outcome)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005004 "A patient-reported outcome that indicates an unfavorable experience or result related to a dental condition or treatment")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005004 "A patient-reported outcome that indicates an unfavorable experience or result related to a dental condition or treatment"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005004 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005004 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005004 <https://orcid.org/0009-0003-7246-1252>)
@@ -6054,7 +6054,7 @@ SubClassOf(obo:OHD_0005004 obo:OHD_0000288)
 
 # Class: obo:OHD_0005005 (avoidance behavior)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005005 "A behavioral defense response in which an organism seeks to avoid an encounter with a potential external threat.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005005 "A behavioral defense response in which an organism seeks to avoid an encounter with a potential external threat."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005005 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005005 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005005 "2025-02-10T00:00:00Z"^^xsd:dateTime)
@@ -6064,7 +6064,7 @@ SubClassOf(obo:OHD_0005005 obo:GO_0002209)
 
 # Class: obo:OHD_0005006 (health encounter avoidance behavior)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005006 "Avoidance behavior that involves delay in seeking healthcare treatment due to fear, anxiety, or other psychological factors.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005006 "Avoidance behavior that involves delay in seeking healthcare treatment due to fear, anxiety, or other psychological factors."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005006 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005006 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005006 "2025-02-10T18:00:21Z"^^xsd:dateTime)
@@ -6074,7 +6074,7 @@ SubClassOf(obo:OHD_0005006 obo:OHD_0005005)
 
 # Class: obo:OHD_0005007 (dental visit avoidance behavior)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005007 "A healthcare visit avoidance behavior that involves delay in seeking dental treatment.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005007 "A healthcare visit avoidance behavior that involves delay in seeking dental treatment."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005007 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005007 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005007 "2025-02-10T18:03:15Z"^^xsd:dateTime)
@@ -6085,7 +6085,7 @@ SubClassOf(obo:OHD_0005007 ObjectAllValuesFrom(obo:BFO_0000063 obo:OHD_0000009))
 
 # Class: obo:OHD_0005010 (health care encounter avoidance behavior that involves delay in scheduling a health care appointment)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005010 "A health care encounter avoidance behavior that involves delay in scheduling a health care appointment due to fear, anxiety, or other psychological factors.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005010 "A health care encounter avoidance behavior that involves delay in scheduling a health care appointment due to fear, anxiety, or other psychological factors."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005010 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005010 "2025-02-12T15:44:15Z"^^xsd:dateTime)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> obo:OHD_0005010 obo:OHD_0005009)
@@ -6094,7 +6094,7 @@ SubClassOf(obo:OHD_0005010 obo:OHD_0005006)
 
 # Class: obo:OHD_0005012 (dental visit avoidance behavior that involves delay in scheduling a dental appointment)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005012 "A dental visit avoidance behavior that involves delay in scheduling a dental appointment due to fear, anxiety, or other psychological factors.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005012 "A dental visit avoidance behavior that involves delay in scheduling a dental appointment due to fear, anxiety, or other psychological factors."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005012 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005012 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005012 "2025-02-12T15:53:10Z"^^xsd:dateTime)
@@ -6104,7 +6104,7 @@ SubClassOf(obo:OHD_0005012 obo:OHD_0005007)
 
 # Class: obo:OHD_0005013 (dental visit avoidance behavior that involves canceling or not showing up for a dental appointment)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005013 "A dental visit avoidance behavior that involves canceling or not showing up for a dental appointment due to fear, anxiety, or other psychological factors.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005013 "A dental visit avoidance behavior that involves canceling or not showing up for a dental appointment due to fear, anxiety, or other psychological factors."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005013 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005013 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005013 "2025-02-12T15:53:59Z"^^xsd:dateTime)
@@ -6114,7 +6114,7 @@ SubClassOf(obo:OHD_0005013 obo:OHD_0005007)
 
 # Class: obo:OHD_0005014 (dental visit avoidance behavior that involves canceling a dental appointment)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005014 "A dental visit avoidance behavior that involves canceling a dental appointment due to fear, anxiety, or other psychological factors.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005014 "A dental visit avoidance behavior that involves canceling a dental appointment due to fear, anxiety, or other psychological factors."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005014 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005014 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005014 "2025-02-12T15:54:27Z"^^xsd:dateTime)
@@ -6124,7 +6124,7 @@ SubClassOf(obo:OHD_0005014 obo:OHD_0005013)
 
 # Class: obo:OHD_0005015 (dental visit avoidance behavior that involves not showing up for a dental appointment)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005015 "A dental visit avoidance behavior that involves not showing up for a dental appointment due to fear, anxiety, or other psychological factors.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0005015 "A dental visit avoidance behavior that involves not showing up for a dental appointment due to fear, anxiety, or other psychological factors."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005015 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0005015 <https://orcid.org/0009-0003-7246-1252>)
 AnnotationAssertion(dcterms:created obo:OHD_0005015 "2025-02-12T15:54:56Z"^^xsd:dateTime)
@@ -6470,7 +6470,7 @@ SubClassOf(obo:OHD_0008036 obo:MF_0000056)
 
 # Class: obo:OHD_0008037 (process before dental visit)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0008037 "A process that happens before a dental visit and concerns some dental encounter.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0008037 "A process that happens before a dental visit and concerns some dental encounter."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0008037 <https://orcid.org/0009-0002-7282-0836>)
 AnnotationAssertion(dcterms:created obo:OHD_0008037 "2025-05-14T01:31:15Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0008037 "process before dental visit"@en)
@@ -6489,7 +6489,7 @@ SubClassOf(obo:OHD_0008038 obo:OGMS_0000060)
 
 # Class: obo:OHD_0008039 (process during dental visit)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0008039 "A process that happens during a dental visit and involves the patient participating in the dental visit.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0008039 "A process that happens during a dental visit and involves the patient participating in the dental visit."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0008039 <https://orcid.org/0009-0002-7282-0836>)
 AnnotationAssertion(dcterms:created obo:OHD_0008039 "2025-03-28T12:51:33Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0008039 "process during dental visit"@en)
@@ -6498,7 +6498,7 @@ SubClassOf(obo:OHD_0008039 obo:BFO_0000015)
 
 # Class: obo:OHD_0008040 (process after dental visit)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0008040 "A process that happens after a dental visit and concerns some dental encounter.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0008040 "A process that happens after a dental visit and concerns some dental encounter."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0008040 <https://orcid.org/0009-0002-7282-0836>)
 AnnotationAssertion(dcterms:created obo:OHD_0008040 "2025-03-28T12:52:05Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0008040 "process after dental visit"@en)
@@ -6887,7 +6887,7 @@ SubClassOf(obo:OHD_0008080 obo:OHD_0008001)
 
 # Class: obo:OHD_0010000 (orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010000 "Pain originating in the orofacial region, which includes the mouth and face.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010000 "Pain originating in the orofacial region, which includes the mouth and face."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010000 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010000 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010000 "2025-04-04T15:42:46Z"^^xsd:dateTime)
@@ -6897,7 +6897,7 @@ SubClassOf(obo:OHD_0010000 obo:OGMS_0000085)
 
 # Class: obo:OHD_0010001 (dental pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010001 "Orofacial pain caused by lesions or disorders affecting one or more teeth or their immediately surrounding and supporting structures: the tooth pulp, periodontium and gingivae.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010001 "Orofacial pain caused by lesions or disorders affecting one or more teeth or their immediately surrounding and supporting structures: the tooth pulp, periodontium and gingivae."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010001 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010001 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010001 "2025-04-04T15:48:49Z"^^xsd:dateTime)
@@ -6909,7 +6909,7 @@ SubClassOf(obo:OHD_0010001 ObjectSomeValuesFrom(obo:OHD_0008006 obo:UBERON_00001
 
 # Class: obo:OHD_0010002 (pulpal pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010002 "Dental pain caused by a lesion or disorder involving the tooth pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010002 "Dental pain caused by a lesion or disorder involving the tooth pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010002 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010002 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010002 <https://orcid.org/0009-0003-5583-4731>)
@@ -6923,7 +6923,7 @@ SubClassOf(obo:OHD_0010002 ObjectSomeValuesFrom(obo:OHD_0008006 obo:UBERON_00017
 
 # Class: obo:OHD_0010003 (myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010003 "Orofacial pain involving the masticatory muscles.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010003 "Orofacial pain involving the masticatory muscles."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010003 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010003 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010003 <https://orcid.org/0009-0003-5583-4731>)
@@ -6938,7 +6938,7 @@ SubClassOf(obo:OHD_0010003 ObjectSomeValuesFrom(obo:OHD_0008006 obo:UBERON_00044
 
 # Class: obo:OHD_0010004 (temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010004 "Orofacial pain involving the temporomandibular joint (TMJ).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010004 "Orofacial pain involving the temporomandibular joint (TMJ)."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010004 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010004 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010004 <https://orcid.org/0009-0003-5583-4731>)
@@ -6952,7 +6952,7 @@ SubClassOf(obo:OHD_0010004 ObjectSomeValuesFrom(obo:OHD_0008006 obo:UBERON_00037
 
 # Class: obo:OHD_0010005 (periodontal pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010005 "Dental pain caused by a lesion or disorder involving the periodontium.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010005 "Dental pain caused by a lesion or disorder involving the periodontium."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010005 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010005 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010005 <https://orcid.org/0009-0003-5583-4731>)
@@ -6968,7 +6968,7 @@ SubClassOf(obo:OHD_0010005 ObjectSomeValuesFrom(obo:OHD_0008006 obo:UBERON_00082
 
 # Class: obo:OHD_0010006 (gingival pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010006 "Dental pain caused by a lesion or disorder involving the gingival tissues.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010006 "Dental pain caused by a lesion or disorder involving the gingival tissues."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010006 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010006 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010006 "2025-04-08T14:34:14Z"^^xsd:dateTime)
@@ -6981,7 +6981,7 @@ SubClassOf(obo:OHD_0010006 ObjectSomeValuesFrom(obo:OHD_0008006 obo:UBERON_00018
 
 # Class: obo:OHD_0010007 (jaw bone pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010007 "Dental pain due to a lesion or disorder involving the jaw bone tissue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010007 "Dental pain due to a lesion or disorder involving the jaw bone tissue."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010007 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010007 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010007 <https://orcid.org/0009-0003-5583-4731>)
@@ -6997,7 +6997,7 @@ SubClassOf(obo:OHD_0010007 ObjectUnionOf(ObjectSomeValuesFrom(obo:OHD_0008006 ob
 
 # Class: obo:OHD_0010008 (pulpal pain due to hypersensitivity)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010008 "Pulpal pain due to hypersensitivity occurring in clinically normal pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010008 "Pulpal pain due to hypersensitivity occurring in clinically normal pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010008 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010008 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010008 <https://orcid.org/0000-0001-9990-8331>)
@@ -7013,7 +7013,7 @@ SubClassOf(obo:OHD_0010008 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010009)
 
 # Class: obo:OHD_0010009 (sensory hypersensitivity)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010009 "A disposition to decreased tolerance to sensory stimuli that triggers emotional or physical distress.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010009 "A disposition to decreased tolerance to sensory stimuli that triggers emotional or physical distress."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010009 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010009 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010009 "2025-06-05T14:17:34Z"^^xsd:dateTime)
@@ -7022,7 +7022,7 @@ SubClassOf(obo:OHD_0010009 obo:BFO_0000016)
 
 # Class: obo:OHD_0010010 (crack in enamel)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010010 "A tooth fracture involving a crack in the enamel which may or may not involve exposure of dentin. A crack typically appears as a line on the surface of the tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010010 "A tooth fracture involving a crack in the enamel which may or may not involve exposure of dentin. A crack typically appears as a line on the surface of the tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010010 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010010 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010010 <https://orcid.org/0009-0003-5583-4731>)
@@ -7032,7 +7032,7 @@ SubClassOf(obo:OHD_0010010 obo:OHD_0000277)
 
 # Class: obo:OHD_0010011 (dental sensory hypersensitivity)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010011 "Sensory hypersensitivity involving a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010011 "Sensory hypersensitivity involving a tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010011 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010011 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010011 "2025-06-05T14:34:40Z"^^xsd:dateTime)
@@ -7041,7 +7041,7 @@ SubClassOf(obo:OHD_0010011 obo:OHD_0010009)
 
 # Class: obo:OHD_0010012 (sensory hypersensitivity due to crack in enamel)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010012 "Dental sensory hypersensitivity related a crack in the enamel of a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010012 "Dental sensory hypersensitivity related a crack in the enamel of a tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010012 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010012 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010012 "2025-06-05T14:40:56Z"^^xsd:dateTime)
@@ -7051,7 +7051,7 @@ SubClassOf(obo:OHD_0010012 obo:OHD_0010011)
 
 # Class: obo:OHD_0010013 (pulpal pain due to crack in enamel)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010013 "Pulpal pain due to hypersensitivity resulting from a crack or incomplete fracture of the affected tooth, involving the enamel with at least one of the following: sharp pain upon biting, pain on release of occlusal biting pressure or external application of force, or cold hypersensitivity.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010013 "Pulpal pain due to hypersensitivity resulting from a crack or incomplete fracture of the affected tooth, involving the enamel with at least one of the following: sharp pain upon biting, pain on release of occlusal biting pressure or external application of force, or cold hypersensitivity."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010013 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010013 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010013 <https://orcid.org/0000-0001-9990-8331>)
@@ -7066,7 +7066,7 @@ SubClassOf(obo:OHD_0010013 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010012)
 
 # Class: obo:OHD_0010014 (dentin hypersensitivity due to exposed dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010014 "Dentin hypersensitivity related to exposed dentin on a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010014 "Dentin hypersensitivity related to exposed dentin on a tooth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010014 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010014 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010014 "2025-06-05T14:53:38Z"^^xsd:dateTime)
@@ -7077,7 +7077,7 @@ SubClassOf(obo:OHD_0010014 obo:OHD_0000043)
 
 # Class: obo:OHD_0010015 (pulpal pain due to exposed dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010015 "Pulpal pain due to hypersensistivity resulting from an exposed dentin surface.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010015 "Pulpal pain due to hypersensistivity resulting from an exposed dentin surface."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010015 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010015 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010015 <https://orcid.org/0000-0001-9990-8331>)
@@ -7092,7 +7092,7 @@ SubClassOf(obo:OHD_0010015 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010014)
 
 # Class: obo:OHD_0010016 (dentin hypersensitivity due to tooth wear or abrasion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010016 "Dentin hypersensitivity related to wear or abrasion of a tooth resulting in exposed dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010016 "Dentin hypersensitivity related to wear or abrasion of a tooth resulting in exposed dentin."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010016 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010016 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010016 "2025-06-05T15:03:12Z"^^xsd:dateTime)
@@ -7102,7 +7102,7 @@ SubClassOf(obo:OHD_0010016 obo:OHD_0010014)
 
 # Class: obo:OHD_0010017 (pulpal pain due to tooth wear or abrasion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010017 "Pulpal pain due to exposed dentin resulting from wear or abrasion on the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010017 "Pulpal pain due to exposed dentin resulting from wear or abrasion on the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010017 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010017 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010017 <https://orcid.org/0000-0001-9990-8331>)
@@ -7117,7 +7117,7 @@ SubClassOf(obo:OHD_0010017 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010016)
 
 # Class: obo:OHD_0010018 (dentin hypersensitivity due to a fracture resulting in exposed dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010018 "Dentin hypersensitivity due to exposed dentin resulting from a tooth fracture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010018 "Dentin hypersensitivity due to exposed dentin resulting from a tooth fracture."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010018 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010018 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010018 "2025-06-05T15:17:38Z"^^xsd:dateTime)
@@ -7127,7 +7127,7 @@ SubClassOf(obo:OHD_0010018 obo:OHD_0010014)
 
 # Class: obo:OHD_0010019 (pulpal pain due to a fracture resulting in exposed dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010019 "Pulpal pain due to exposed dentin resulting from a fracture of the affected tooth involving the enamel, root cementum, dentin, or any combination thereof.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010019 "Pulpal pain due to exposed dentin resulting from a fracture of the affected tooth involving the enamel, root cementum, dentin, or any combination thereof."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010019 "PMID:32103673")
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010019 "https://doi.org/10.1177/0333102419893823")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010019 <https://orcid.org/0000-0001-9990-8331>)
@@ -7142,16 +7142,16 @@ SubClassOf(obo:OHD_0010019 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010018)
 
 # Class: obo:OHD_0010020 (reversible pulpitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010020 "Pulpitis that has not yet progressed to being permanent.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010020 "Pulpitis that has not yet progressed to being permanent."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010020 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010020 <https://orcid.org/0009-0003-5583-4731>)
-AnnotationAssertion(rdfs:label obo:OHD_0010020 "reversible pulpitis")
+AnnotationAssertion(rdfs:label obo:OHD_0010020 "reversible pulpitis"@en)
 SubClassOf(obo:OHD_0010020 obo:OHD_0010060)
 SubClassOf(obo:OHD_0010020 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0010062))
 
 # Class: obo:OHD_0010021 (periodontitis due to operation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010021 "Periodontitis due to injury occuring because of an operation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010021 "Periodontitis due to injury occuring because of an operation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010021 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010021 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010021 "2025-06-19T18:48:48Z"^^xsd:dateTime)
@@ -7161,7 +7161,7 @@ SubClassOf(obo:OHD_0010021 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000044))
 
 # Class: obo:OHD_0010022 (oral mucosal pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010022 "Pain due to a disease or disorder involving the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010022 "Pain due to a disease or disorder involving the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010022 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010022 "1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010022 <https://orcid.org/0009-0003-5583-4731>)
@@ -7173,7 +7173,7 @@ SubClassOf(obo:OHD_0010022 ObjectSomeValuesFrom(obo:OHD_0008006 obo:UBERON_00003
 
 # Class: obo:OHD_0010023 (salivary gland pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010023 "Pain due to a lesion or disorder involving the salivary glands.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010023 "Pain due to a lesion or disorder involving the salivary glands."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010023 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010023 "1.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010023 <https://orcid.org/0009-0003-5583-4731>)
@@ -7186,7 +7186,7 @@ SubClassOf(obo:OHD_0010023 obo:OHD_0010186)
 
 # Class: obo:OHD_0010024 (gingival pain due to gingivitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010024 "Gingival pain due to gingival inflammation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010024 "Gingival pain due to gingival inflammation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010024 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010024 "1.1.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010024 <https://orcid.org/0009-0003-5583-4731>)
@@ -7200,7 +7200,7 @@ SubClassOf(obo:OHD_0010024 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010025))
 
 # Class: obo:OHD_0010025 (gingivitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010025 "A gingival disorder involving inflammation of the gingival tissue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010025 "A gingival disorder involving inflammation of the gingival tissue."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010025 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010025 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010025 "2025-06-10T17:58:35Z"^^xsd:dateTime)
@@ -7210,7 +7210,7 @@ SubClassOf(obo:OHD_0010025 obo:OHD_0010115)
 
 # Class: obo:OHD_0010026 (gingivitis due to infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010026 "Gingivitis due to an infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010026 "Gingivitis due to an infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010026 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010026 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010026 "2025-06-10T18:08:21Z"^^xsd:dateTime)
@@ -7220,7 +7220,7 @@ SubClassOf(obo:OHD_0010026 ObjectSomeValuesFrom(obo:RO_0002410 obo:IDO_0000586))
 
 # Class: obo:OHD_0010027 (gingival pain due to infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010027 "Gingival pain due to gingivitis due to an infection of the gingival tissue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010027 "Gingival pain due to gingivitis due to an infection of the gingival tissue."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010027 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010027 "1.1.3.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010027 <https://orcid.org/0009-0003-5583-4731>)
@@ -7232,7 +7232,7 @@ SubClassOf(obo:OHD_0010027 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010026))
 
 # Class: obo:OHD_0010028 (exposed dental pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010028 "A tooth disorder invovling the exposure of dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010028 "A tooth disorder invovling the exposure of dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010028 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010028 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010028 "2025-06-23T19:47:27Z"^^xsd:dateTime)
@@ -7241,7 +7241,7 @@ SubClassOf(obo:OHD_0010028 obo:OHD_0000260)
 
 # Class: obo:OHD_0010029 (gingivitis due to bacterial infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010029 "Gingivitis due to a bacterial infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010029 "Gingivitis due to a bacterial infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010029 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010029 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010029 "2025-06-10T18:30:06Z"^^xsd:dateTime)
@@ -7251,7 +7251,7 @@ SubClassOf(obo:OHD_0010029 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0010096)
 
 # Class: obo:OHD_0010030 (gingival pain due to bacterial infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010030 "Gingival pain due to infection resulting form bacteria.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010030 "Gingival pain due to infection resulting form bacteria."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010030 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010030 "1.1.3.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010030 <https://orcid.org/0009-0003-5583-4731>)
@@ -7263,7 +7263,7 @@ SubClassOf(obo:OHD_0010030 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010029))
 
 # Class: obo:OHD_0010031 (viral infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010031 "An infectious disorder caused by viruses.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010031 "An infectious disorder caused by viruses."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010031 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010031 "2025-06-10T18:41:27Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010031 "viral infection"@en)
@@ -7271,7 +7271,7 @@ SubClassOf(obo:OHD_0010031 obo:IDO_0000504)
 
 # Class: obo:OHD_0010032 (gingivitis due to viral infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010032 "Gingivitis due to a viral infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010032 "Gingivitis due to a viral infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010032 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010032 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010032 "2025-06-10T18:44:24Z"^^xsd:dateTime)
@@ -7281,7 +7281,7 @@ SubClassOf(obo:OHD_0010032 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0010031)
 
 # Class: obo:OHD_0010033 (gingival pain due to viral infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010033 "Gingival pain due to infection resulting from a virus.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010033 "Gingival pain due to infection resulting from a virus."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010033 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010033 "1.1.3.1.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010033 <https://orcid.org/0009-0003-5583-4731>)
@@ -7293,7 +7293,7 @@ SubClassOf(obo:OHD_0010033 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010032))
 
 # Class: obo:OHD_0010034 (fungal infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010034 "An infectious disorder caused by fungi.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010034 "An infectious disorder caused by fungi."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010034 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010034 "2025-06-10T19:01:22Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010034 "fungal infection"@en)
@@ -7301,7 +7301,7 @@ SubClassOf(obo:OHD_0010034 obo:IDO_0000504)
 
 # Class: obo:OHD_0010035 (gingivitis due to fungal infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010035 "Gingivitis due to a fungal infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010035 "Gingivitis due to a fungal infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010035 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010035 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010035 "2025-06-10T19:02:08Z"^^xsd:dateTime)
@@ -7311,7 +7311,7 @@ SubClassOf(obo:OHD_0010035 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0010034)
 
 # Class: obo:OHD_0010036 (gingival pain due to fungal infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010036 "Gingival pain due to infection resulting from a fungus.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010036 "Gingival pain due to infection resulting from a fungus."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010036 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010036 "1.1.3.1.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010036 <https://orcid.org/0009-0003-5583-4731>)
@@ -7323,7 +7323,7 @@ SubClassOf(obo:OHD_0010036 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010035))
 
 # Class: obo:OHD_0010037 (salivary gland pain due to infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010037 "Salivary gland pain due to infection of the salivary glands.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010037 "Salivary gland pain due to infection of the salivary glands."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010037 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010037 "1.2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010037 <https://orcid.org/0009-0003-5583-4731>)
@@ -7335,7 +7335,7 @@ SubClassOf(obo:OHD_0010037 ObjectSomeValuesFrom(obo:RO_0002410 obo:IDO_0000586))
 
 # Class: obo:OHD_0010038 (salivary gland pain due to bacterial infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010038 "Salivary gland pain due to bacterial infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010038 "Salivary gland pain due to bacterial infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010038 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010038 "1.2.2.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010038 <https://orcid.org/0009-0003-5583-4731>)
@@ -7347,7 +7347,7 @@ SubClassOf(obo:OHD_0010038 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010096))
 
 # Class: obo:OHD_0010039 (salivary gland pain due to viral infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010039 "Salivary gland pain due to viral infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010039 "Salivary gland pain due to viral infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010039 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010039 "1.2.2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010039 <https://orcid.org/0009-0003-5583-4731>)
@@ -7359,7 +7359,7 @@ SubClassOf(obo:OHD_0010039 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010031))
 
 # Class: obo:OHD_0010040 (oral mucosal pain due to infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010040 "Oral mucosal pain due to oral mucosal inflammation resulting from an infection of the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010040 "Oral mucosal pain due to oral mucosal inflammation resulting from an infection of the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010040 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010040 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010040 "2025-06-10T19:33:29Z"^^xsd:dateTime)
@@ -7371,7 +7371,7 @@ SubClassOf(obo:OHD_0010040 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010043))
 
 # Class: obo:OHD_0010041 (oral mucosal pain due to oral mucosal inflammation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010041 "Oral mucosa pain due to inflamation of the oral mucosa, with pain that has developed in close temporal relation to the inflammation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010041 "Oral mucosa pain due to inflamation of the oral mucosa, with pain that has developed in close temporal relation to the inflammation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010041 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010041 "1.2.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010041 <https://orcid.org/0009-0003-5583-4731>)
@@ -7385,7 +7385,7 @@ SubClassOf(obo:OHD_0010041 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010042))
 
 # Class: obo:OHD_0010042 (oral mucosal inflammation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010042 "An inflammatory response causing inflammation in the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010042 "An inflammatory response causing inflammation in the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010042 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010042 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010042 "2025-06-10T19:39:13Z"^^xsd:dateTime)
@@ -7396,7 +7396,7 @@ SubClassOf(obo:OHD_0010042 ObjectSomeValuesFrom(obo:BFO_0000066 obo:UBERON_00003
 
 # Class: obo:OHD_0010043 (oral mucosal inflammation due to infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010043 "Oral mucosal inflammation occuring due to an infection within the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010043 "Oral mucosal inflammation occuring due to an infection within the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010043 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010043 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010043 "2025-06-10T19:44:06Z"^^xsd:dateTime)
@@ -7406,7 +7406,7 @@ SubClassOf(obo:OHD_0010043 ObjectSomeValuesFrom(obo:RO_0002410 obo:IDO_0000586))
 
 # Class: obo:OHD_0010044 (oral mucosal inflammation due to bacterial infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010044 "Oral mucosal inflammation occuring due to a bacterial infection within the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010044 "Oral mucosal inflammation occuring due to a bacterial infection within the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010044 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010044 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010044 "2025-06-10T19:51:14Z"^^xsd:dateTime)
@@ -7416,7 +7416,7 @@ SubClassOf(obo:OHD_0010044 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0010096)
 
 # Class: obo:OHD_0010045 (oral mucosal pain due to bacterial infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010045 "Oral mucosal pain due to bacterial infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010045 "Oral mucosal pain due to bacterial infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010045 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010045 "1.2.1.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010045 <https://orcid.org/0009-0003-5583-4731>)
@@ -7428,7 +7428,7 @@ SubClassOf(obo:OHD_0010045 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010044))
 
 # Class: obo:OHD_0010046 (oral mucosal inflammation due to viral infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010046 "Oral mucosal inflammation occuring due to a viral infection within the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010046 "Oral mucosal inflammation occuring due to a viral infection within the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010046 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010046 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010046 "2025-06-10T19:57:38Z"^^xsd:dateTime)
@@ -7438,7 +7438,7 @@ SubClassOf(obo:OHD_0010046 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010031))
 
 # Class: obo:OHD_0010047 (oral mucosal pain due to viral infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010047 "Oral mucosal pain due to viral infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010047 "Oral mucosal pain due to viral infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010047 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010047 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010047 "2025-06-10T19:59:20Z"^^xsd:dateTime)
@@ -7450,7 +7450,7 @@ SubClassOf(obo:OHD_0010047 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010046))
 
 # Class: obo:OHD_0010048 (oral mucosal inflammation due to fungal infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010048 "Oral mucosal inflammation occuring due to a fungal infection within the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010048 "Oral mucosal inflammation occuring due to a fungal infection within the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010048 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010048 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010048 "2025-06-10T20:03:18Z"^^xsd:dateTime)
@@ -7460,7 +7460,7 @@ SubClassOf(obo:OHD_0010048 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0010034)
 
 # Class: obo:OHD_0010049 (oral mucosal pain due to fungal infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010049 "Oral mucosal pain due to fungal infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010049 "Oral mucosal pain due to fungal infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010049 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010049 "1.2.1.1.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010049 <https://orcid.org/0009-0003-5583-4731>)
@@ -7472,7 +7472,7 @@ SubClassOf(obo:OHD_0010049 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010048))
 
 # Class: obo:OHD_0010050 (jaw bone pain due to infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010050 "Jaw bone pain due to an infection of the jaw bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010050 "Jaw bone pain due to an infection of the jaw bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010050 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010050 "1.2.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010050 <https://orcid.org/0009-0003-5583-4731>)
@@ -7484,7 +7484,7 @@ SubClassOf(obo:OHD_0010050 ObjectSomeValuesFrom(obo:RO_0002410 obo:IDO_0000586))
 
 # Class: obo:OHD_0010051 (jaw bone pain due to bacterial infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010051 "Jaw bone pain due to a bacterial infection in the jaw bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010051 "Jaw bone pain due to a bacterial infection in the jaw bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010051 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010051 "1.2.3.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010051 <https://orcid.org/0009-0003-5583-4731>)
@@ -7495,7 +7495,7 @@ SubClassOf(obo:OHD_0010051 obo:OHD_0010050)
 
 # Class: obo:OHD_0010052 (jaw bone pain due to viral infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010052 "Jaw bone pain due to a viral infection in the jaw bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010052 "Jaw bone pain due to a viral infection in the jaw bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010052 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010052 "1.2.3.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010052 <https://orcid.org/0009-0003-5583-4731>)
@@ -7507,7 +7507,7 @@ SubClassOf(obo:OHD_0010052 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010031))
 
 # Class: obo:OHD_0010053 (jaw bone pain due to fungal infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010053 "Jaw bone pain due to a fungal infection in the jaw bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010053 "Jaw bone pain due to a fungal infection in the jaw bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010053 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010053 "1.2.3.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010053 <https://orcid.org/0009-0003-5583-4731>)
@@ -7519,7 +7519,7 @@ SubClassOf(obo:OHD_0010053 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010034))
 
 # Class: obo:OHD_0010054 (gingivitis due to injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010054 "Gingivitis caused by  structural damage to the gingival tissue from an external force.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010054 "Gingivitis caused by  structural damage to the gingival tissue from an external force."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010054 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010054 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010054 "2025-06-11T17:45:20Z"^^xsd:dateTime)
@@ -7529,7 +7529,7 @@ SubClassOf(obo:OHD_0010054 ObjectSomeValuesFrom(obo:RO_0002410 obo:OGMS_0000102)
 
 # Class: obo:OHD_0010055 (gingival pain due to injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010055 "Gingival pain due to gingivitis due to resulting from trauma or injury with pain localizaed to the traumatized tissue that develops within minutes or days after the trauma.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010055 "Gingival pain due to gingivitis due to resulting from trauma or injury with pain localizaed to the traumatized tissue that develops within minutes or days after the trauma."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010055 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010055 "1.1.3.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010055 <https://orcid.org/0009-0003-5583-4731>)
@@ -7541,7 +7541,7 @@ SubClassOf(obo:OHD_0010055 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010054))
 
 # Class: obo:OHD_0010056 (oral mucosal inflammation due to injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010056 "Oral mucosal inflammation caused by structural damage to the oral mucosa from an external force.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010056 "Oral mucosal inflammation caused by structural damage to the oral mucosa from an external force."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010056 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010056 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010056 "2025-06-11T17:53:05Z"^^xsd:dateTime)
@@ -7551,7 +7551,7 @@ SubClassOf(obo:OHD_0010056 ObjectSomeValuesFrom(obo:RO_0002410 obo:OGMS_0000102)
 
 # Class: obo:OHD_0010057 (oral mucosal pain due to injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010057 "Oral mucosal pain due to oral mucose inflammation resulting from tauma to the oral mucosa tissue with pain that is localized to the traumatized tissue and developed within minutes to days after the trauma.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010057 "Oral mucosal pain due to oral mucose inflammation resulting from tauma to the oral mucosa tissue with pain that is localized to the traumatized tissue and developed within minutes to days after the trauma."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010057 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010057 "1.2.1.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010057 <https://orcid.org/0009-0003-5583-4731>)
@@ -7563,7 +7563,7 @@ SubClassOf(obo:OHD_0010057 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010056))
 
 # Class: obo:OHD_0010058 (jaw bone pain due to injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010058 "Jaw bone pain due to trauma or injury involving the jaw bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010058 "Jaw bone pain due to trauma or injury involving the jaw bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010058 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010058 "1.2.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010058 <https://orcid.org/0009-0003-5583-4731>)
@@ -7575,7 +7575,7 @@ SubClassOf(obo:OHD_0010058 ObjectSomeValuesFrom(obo:RO_0002410 obo:OGMS_0000102)
 
 # Class: obo:OHD_0010059 (pain due to lesion or disease of the trigeminal nerve)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010059 "Orofacial pain attributed to lesion or disease of the trigeminal nerve.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010059 "Orofacial pain attributed to lesion or disease of the trigeminal nerve."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010059 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010059 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010059 "2025-06-11T18:05:48Z"^^xsd:dateTime)
@@ -7586,7 +7586,7 @@ SubClassOf(obo:OHD_0010059 obo:OHD_0010142)
 
 # Class: obo:OHD_0010060 (pulpitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010060 "An inflammatory response causing inflammation of the pulpal tissue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010060 "An inflammatory response causing inflammation of the pulpal tissue."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010060 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010060 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010060 "2025-06-11T18:15:26Z"^^xsd:dateTime)
@@ -7595,7 +7595,7 @@ SubClassOf(obo:OHD_0010060 obo:OHD_0000260)
 
 # Class: obo:OHD_0010061 (pulpal pain due to pulpitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010061 "Pulpal pain due to diagnosed pulpitis in affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010061 "Pulpal pain due to diagnosed pulpitis in affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010061 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010061 "1.1.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010061 <https://orcid.org/0009-0003-5583-4731>)
@@ -7609,7 +7609,7 @@ SubClassOf(obo:OHD_0010061 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010060))
 
 # Class: obo:OHD_0010062 (reversible disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010062 "A disorder that has not yet progressed to being permanent.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010062 "A disorder that has not yet progressed to being permanent."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010062 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010062 "2025-06-11T18:26:01Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010062 "reversible disorder"@en)
@@ -7617,7 +7617,7 @@ SubClassOf(obo:OHD_0010062 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010063 (irreversible disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010063 "A disorder that is permanent.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010063 "A disorder that is permanent."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010063 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010063 "2025-06-11T18:31:46Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010063 "irreversible disorder"@en)
@@ -7625,7 +7625,7 @@ SubClassOf(obo:OHD_0010063 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010064 (irreversible pulpitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010064 "Pulpitis that is permanent.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010064 "Pulpitis that is permanent."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010064 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010064 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010064 "2025-06-11T18:32:32Z"^^xsd:dateTime)
@@ -7635,7 +7635,7 @@ SubClassOf(obo:OHD_0010064 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0010063)
 
 # Class: obo:OHD_0010065 (dentin infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010065 "An infection occuring within the dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010065 "An infection occuring within the dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010065 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010065 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010065 "2025-06-11T18:46:27Z"^^xsd:dateTime)
@@ -7645,7 +7645,7 @@ SubClassOf(obo:OHD_0010065 ObjectSomeValuesFrom(obo:BFO_0000066 obo:UBERON_00017
 
 # Class: obo:OHD_0010066 (reversible pulpitis due to dentin infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010066 "Reverisble pulpitis due to an infection within the dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010066 "Reverisble pulpitis due to an infection within the dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010066 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010066 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010066 "2025-06-11T18:50:51Z"^^xsd:dateTime)
@@ -7655,7 +7655,7 @@ SubClassOf(obo:OHD_0010066 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010065))
 
 # Class: obo:OHD_0010067 (pulpal pain due to reversible pulpitis resulting from a dentin infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010067 "Pulpal pain due to pulpitis that is reversible due to an infection in the dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010067 "Pulpal pain due to pulpitis that is reversible due to an infection in the dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010067 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010067 "1.1.1.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010067 <https://orcid.org/0009-0003-5583-4731>)
@@ -7667,7 +7667,7 @@ SubClassOf(obo:OHD_0010067 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010066))
 
 # Class: obo:OHD_0010068 (irreversible pulpitis due to dentin infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010068 "Irreverisble pulpitis due to an infection within the dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010068 "Irreverisble pulpitis due to an infection within the dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010068 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010068 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010068 "2025-06-11T18:57:00Z"^^xsd:dateTime)
@@ -7677,7 +7677,7 @@ SubClassOf(obo:OHD_0010068 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010065))
 
 # Class: obo:OHD_0010069 (pulpal pain due to irreversible pulpitis resulting from a dentin infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010069 "Pulpal pain attributed to pulpitis that is reversible due to an infection in the dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010069 "Pulpal pain attributed to pulpitis that is reversible due to an infection in the dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010069 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010069 "1.1.1.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010069 <https://orcid.org/0009-0003-5583-4731>)
@@ -7689,7 +7689,7 @@ SubClassOf(obo:OHD_0010069 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010068))
 
 # Class: obo:OHD_0010070 (periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010070 "A periodontal disorder that results from inflammation of the periodontium.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010070 "A periodontal disorder that results from inflammation of the periodontium."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010070 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010070 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010070 "2025-06-11T19:03:19Z"^^xsd:dateTime)
@@ -7700,7 +7700,7 @@ SubClassOf(obo:OHD_0010070 ObjectSomeValuesFrom(obo:RO_0001025 obo:UBERON_000826
 
 # Class: obo:OHD_0010071 (periodontal pain due to periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010071 "Periodontal pain due to periodontal inflammation")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010071 "Periodontal pain due to periodontal inflammation"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010071 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010071 "1.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010071 <https://orcid.org/0009-0003-5583-4731>)
@@ -7712,7 +7712,7 @@ SubClassOf(obo:OHD_0010071 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010070))
 
 # Class: obo:OHD_0010072 (periodontitis due to injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010072 "Periodontitis caused by  structural damage to the periodontium from an external force.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010072 "Periodontitis caused by  structural damage to the periodontium from an external force."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010072 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010072 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010072 "2025-06-11T19:56:24Z"^^xsd:dateTime)
@@ -7722,7 +7722,7 @@ SubClassOf(obo:OHD_0010072 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OGMS_0000102
 
 # Class: obo:OHD_0010073 (periodontal pain due to injury-induced periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010073 "Periodontal pain attributed to periodontitis because of trauma or injury that has occured to the periodontal tissue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010073 "Periodontal pain attributed to periodontitis because of trauma or injury that has occured to the periodontal tissue."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010073 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010073 "1.1.2.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010073 <https://orcid.org/0009-0003-5583-4731>)
@@ -7736,7 +7736,7 @@ SubClassOf(obo:OHD_0010073 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010072))
 
 # Class: obo:OHD_0010074 (developmental dental hard tissue defect)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010074 "A tooth disorder resulting in a developmental defect of a tooth involving the enamel, root cementum or dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010074 "A tooth disorder resulting in a developmental defect of a tooth involving the enamel, root cementum or dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010074 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010074 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010074 "2025-06-12T16:47:16Z"^^xsd:dateTime)
@@ -7745,7 +7745,7 @@ SubClassOf(obo:OHD_0010074 obo:OHD_0000260)
 
 # Class: obo:OHD_0010075 (dentin hypersensitivity due to developmental dental hard tissue defect)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010075 "Dentin hypersensitivity due to exposed dentin resulting from a developmental dental hard tissue defect.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010075 "Dentin hypersensitivity due to exposed dentin resulting from a developmental dental hard tissue defect."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010075 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010075 "2025-06-12T16:52:56Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010075 "dentin hypersensitivity due to developmental dental hard tissue defect"@en)
@@ -7754,7 +7754,7 @@ SubClassOf(obo:OHD_0010075 obo:OHD_0010014)
 
 # Class: obo:OHD_0010076 (pulpal pain due to developmental dental hard tissue defect)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010076 "Pulpal pain due to a developmental defect of the affected tooth involving the enamel, root cementum, or dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010076 "Pulpal pain due to a developmental defect of the affected tooth involving the enamel, root cementum, or dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010076 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010076 "1.1.1.1.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010076 <https://orcid.org/0009-0003-5583-4731>)
@@ -7766,7 +7766,7 @@ SubClassOf(obo:OHD_0010076 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010075)
 
 # Class: obo:OHD_0010077 (dentin hypersensitivity due to dental procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010077 "Dentin hypersensitivity related to a dental procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010077 "Dentin hypersensitivity related to a dental procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010077 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010077 "2025-06-12T17:28:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010077 "dentin hypersensitivity due to dental procedure"@en)
@@ -7775,7 +7775,7 @@ SubClassOf(obo:OHD_0010077 obo:OHD_0000043)
 
 # Class: obo:OHD_0010078 (pulpal pain due to dental procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010078 "Pulpal pain due to hypersensitivity resulting from a recent dental procedure to the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010078 "Pulpal pain due to hypersensitivity resulting from a recent dental procedure to the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010078 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010078 "1.1.1.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010078 <https://orcid.org/0009-0003-5583-4731>)
@@ -7787,7 +7787,7 @@ SubClassOf(obo:OHD_0010078 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000002))
 
 # Class: obo:OHD_0010079 (dental caries not extending to the pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010079 "Dental caries that have not extended into the dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010079 "Dental caries that have not extended into the dental pulp."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010079 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010079 "2025-06-12T18:00:10Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010079 "dental caries not extending to the pulp"@en)
@@ -7795,7 +7795,7 @@ SubClassOf(obo:OHD_0010079 obo:OHD_0000031)
 
 # Class: obo:OHD_0010080 (reversible pulpitis due to dental caries not extending to the pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010080 "Reversible pulpitis due dental caries that have not extended to the dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010080 "Reversible pulpitis due dental caries that have not extended to the dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010080 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010080 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010080 "2025-06-12T18:12:50Z"^^xsd:dateTime)
@@ -7805,7 +7805,7 @@ SubClassOf(obo:OHD_0010080 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010079))
 
 # Class: obo:OHD_0010081 (pulpal pain due to reversible pulpitis resulting from caries not extending to the pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010081 "Pulpal pain cuased by reversible pulpitis due to an infection of the dentin with no clinical or radiographic evidence of extension to the pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010081 "Pulpal pain cuased by reversible pulpitis due to an infection of the dentin with no clinical or radiographic evidence of extension to the pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010081 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010081 "1.1.1.3.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010081 <https://orcid.org/0009-0003-5583-4731>)
@@ -7817,7 +7817,7 @@ SubClassOf(obo:OHD_0010081 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010080))
 
 # Class: obo:OHD_0010082 (reversible pulpitis due to dental hard tissue fracture with exposed dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010082 "Reversible pulpitis dental hard-tissue fracture involving exposed dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010082 "Reversible pulpitis dental hard-tissue fracture involving exposed dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010082 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010082 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010082 "2025-06-12T18:26:48Z"^^xsd:dateTime)
@@ -7827,7 +7827,7 @@ SubClassOf(obo:OHD_0010082 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000413))
 
 # Class: obo:OHD_0010083 (pulpal pain due to reversible pulpitis resulting from dental hard-tissue defect with exposed dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010083 "Pulpal pain caused by reversible pulpitis due to infection of the dentin with clinical and/or radiographic evidence of a fracture of the following in the affected tooth, with exposure of dentin: enamel alone, enamel and dentin, root cementum alone, root cementum and dentin, enamel, or root cementum and dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010083 "Pulpal pain caused by reversible pulpitis due to infection of the dentin with clinical and/or radiographic evidence of a fracture of the following in the affected tooth, with exposure of dentin: enamel alone, enamel and dentin, root cementum alone, root cementum and dentin, enamel, or root cementum and dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010083 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010083 "1.1.1.3.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010083 <https://orcid.org/0009-0003-5583-4731>)
@@ -7839,7 +7839,7 @@ SubClassOf(obo:OHD_0010083 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010082))
 
 # Class: obo:OHD_0010084 (dental caries extending to the pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010084 "Dental caries that have extended into the dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010084 "Dental caries that have extended into the dental pulp."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010084 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010084 "2025-06-12T19:01:28Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010084 "dental caries extending to the pulp"@en)
@@ -7848,7 +7848,7 @@ SubClassOf(obo:OHD_0010084 obo:OHD_0000031)
 
 # Class: obo:OHD_0010085 (irreversible pulpitis due to dental caries extending to the pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010085 "Irreversible pulpitis due dental caries that have extended into the dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010085 "Irreversible pulpitis due dental caries that have extended into the dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010085 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010085 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010085 "2025-06-12T19:09:08Z"^^xsd:dateTime)
@@ -7858,7 +7858,7 @@ SubClassOf(obo:OHD_0010085 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010084))
 
 # Class: obo:OHD_0010086 (pulpal due to irreversible pulpitis resulting from caries extending to the pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010086 "Pulpal pain attributed to irreversible pulpitis due to infection of dentin because of deep caries in the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010086 "Pulpal pain attributed to irreversible pulpitis due to infection of dentin because of deep caries in the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010086 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010086 "1.1.1.3.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010086 <https://orcid.org/0009-0003-5583-4731>)
@@ -7870,7 +7870,7 @@ SubClassOf(obo:OHD_0010086 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010068))
 
 # Class: obo:OHD_0010087 (postoperative periodontal pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010087 "Periodontal pain due to traumatically induced periodontal inflammation which has been caused by surgical intervention.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010087 "Periodontal pain due to traumatically induced periodontal inflammation which has been caused by surgical intervention."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010087 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010087 "1.1.2.1.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010087 <https://orcid.org/0009-0003-5583-4731>)
@@ -7882,7 +7882,7 @@ SubClassOf(obo:OHD_0010087 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010021))
 
 # Class: obo:OHD_0010088 (apical periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010088 "Periodontitis occuring around the apex of the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010088 "Periodontitis occuring around the apex of the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010088 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010088 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010088 "2025-06-19T19:04:30Z"^^xsd:dateTime)
@@ -7891,7 +7891,7 @@ SubClassOf(obo:OHD_0010088 obo:OHD_0010070)
 
 # Class: obo:OHD_0010089 (endodontic disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010089 "A mouth disease occuring within the tooth pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010089 "A mouth disease occuring within the tooth pulp."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010089 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010089 "2025-06-19T19:08:06Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010089 "endodontic disease"@en)
@@ -7900,7 +7900,7 @@ SubClassOf(obo:OHD_0010089 ObjectSomeValuesFrom(obo:RO_0000052 obo:UBERON_000175
 
 # Class: obo:OHD_0010090 (apical periodontitis due to endodontic disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010090 "Apical periodontitis occuring because of a diagnosed endodontic disease.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010090 "Apical periodontitis occuring because of a diagnosed endodontic disease."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010090 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010090 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010090 "2025-06-19T19:09:00Z"^^xsd:dateTime)
@@ -7910,7 +7910,7 @@ SubClassOf(obo:OHD_0010090 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010089))
 
 # Class: obo:OHD_0010091 (periodontal pain due to apical periodontitis resulting from endodontic disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010091 "Periodontal pain due to periodontits that is apical occuring becayse of an endodontic disease.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010091 "Periodontal pain due to periodontits that is apical occuring becayse of an endodontic disease."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010091 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010091 "1.1.2.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010091 <https://orcid.org/0009-0003-5583-4731>)
@@ -7922,7 +7922,7 @@ SubClassOf(obo:OHD_0010091 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010090))
 
 # Class: obo:OHD_0010092 (exposed dental pulp due to dental injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010092 "Exposed dental pulp occuring because of some dental injury.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010092 "Exposed dental pulp occuring because of some dental injury."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010092 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010092 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010092 "2025-06-23T19:50:16Z"^^xsd:dateTime)
@@ -7932,7 +7932,7 @@ SubClassOf(obo:OHD_0010092 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010148))
 
 # Class: obo:OHD_0010093 (pulpal pain due to pulp exposure resulting from dental trauma)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010093 "Pulpal pain due to dental trauma that has exposes vital pulp tissue in the affected tooth because of any of the following: fracture involving enamel, dentin and pulp (complicated crown fracture), fracture involving root cementum, dentin and pulp (complicated root fracture), and fracture involving enamel, root cementum, dentin and pulp (complicated crown-root fracture) and occurs within minutes to hours after the trauma.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010093 "Pulpal pain due to dental trauma that has exposes vital pulp tissue in the affected tooth because of any of the following: fracture involving enamel, dentin and pulp (complicated crown fracture), fracture involving root cementum, dentin and pulp (complicated root fracture), and fracture involving enamel, root cementum, dentin and pulp (complicated crown-root fracture) and occurs within minutes to hours after the trauma."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010093 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010093 "1.1.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010093 <https://orcid.org/0009-0003-5583-4731>)
@@ -7944,7 +7944,7 @@ SubClassOf(obo:OHD_0010093 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010092))
 
 # Class: obo:OHD_0010094 (tooth crack)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010094 "A tooth fracture that is not complete, meaning the tooth is still intact.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010094 "A tooth fracture that is not complete, meaning the tooth is still intact."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010094 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010094 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010094 "2025-06-23T20:10:14Z"^^xsd:dateTime)
@@ -7953,7 +7953,7 @@ SubClassOf(obo:OHD_0010094 obo:OHD_0000277)
 
 # Class: obo:OHD_0010095 (tooth crack without evidence of missing tooth substance)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010095 "A tooth crack that does not involve any loss of enamel or dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010095 "A tooth crack that does not involve any loss of enamel or dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010095 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010095 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010095 "2025-06-23T20:12:54Z"^^xsd:dateTime)
@@ -7962,7 +7962,7 @@ SubClassOf(obo:OHD_0010095 obo:OHD_0010094)
 
 # Class: obo:OHD_0010096 (bacterial infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010096 "An infectious disorder caused by bacteria.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010096 "An infectious disorder caused by bacteria."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010096 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010096 "2025-06-16T14:52:46Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010096 "bacterial infection"@en)
@@ -7970,7 +7970,7 @@ SubClassOf(obo:OHD_0010096 obo:IDO_0000504)
 
 # Class: obo:OHD_0010097 (dental pulp infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010097 "An infection that occurs within the dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010097 "An infection that occurs within the dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010097 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010097 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010097 "2025-06-16T18:25:26Z"^^xsd:dateTime)
@@ -7980,7 +7980,7 @@ SubClassOf(obo:OHD_0010097 ObjectSomeValuesFrom(obo:BFO_0000066 obo:UBERON_00017
 
 # Class: obo:OHD_0010098 (irreversible pulpitis due to dental pulp infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010098 "Irreversible pulpitis occuring due to an infection within the dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010098 "Irreversible pulpitis occuring due to an infection within the dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010098 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010098 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010098 "2025-06-16T18:27:39Z"^^xsd:dateTime)
@@ -7990,7 +7990,7 @@ SubClassOf(obo:OHD_0010098 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010097))
 
 # Class: obo:OHD_0010099 (pulpal pain due to irreversible pulpitis resulting from an infection of the dental pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010099 "Pulpal pain due to irreversible pulpitis caused by an infection in the pulp of the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010099 "Pulpal pain due to irreversible pulpitis caused by an infection in the pulp of the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010099 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010099 "1.1.1.3.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010099 <https://orcid.org/0009-0003-5583-4731>)
@@ -8002,7 +8002,7 @@ SubClassOf(obo:OHD_0010099 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010098))
 
 # Class: obo:OHD_0010100 (periodontal disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010100 "A mouth disease occuring within the periodontium.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010100 "A mouth disease occuring within the periodontium."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010100 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010100 "2025-06-16T18:34:32Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010100 "periodontal disease"@en)
@@ -8011,7 +8011,7 @@ SubClassOf(obo:OHD_0010100 ObjectSomeValuesFrom(obo:RO_0000052 obo:UBERON_000826
 
 # Class: obo:OHD_0010101 (periodontitis due to periodontal disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010101 "Periodontitis resulting from a disease within the periodontium.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010101 "Periodontitis resulting from a disease within the periodontium."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010101 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010101 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010101 "2025-06-16T18:37:16Z"^^xsd:dateTime)
@@ -8021,7 +8021,7 @@ SubClassOf(obo:OHD_0010101 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010290))
 
 # Class: obo:OHD_0010102 (periodontal pain due to periodontal disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010102 "Periodontal pain due to periodontitis resulting from a periodontal disease that has been diagnosed.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010102 "Periodontal pain due to periodontitis resulting from a periodontal disease that has been diagnosed."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010102 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010102 "1.1.2.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010102 <https://orcid.org/0009-0003-5583-4731>)
@@ -8033,7 +8033,7 @@ SubClassOf(obo:OHD_0010102 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010100)
 
 # Class: obo:OHD_0010103 (chronic periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010103 "Periodontitis that invovles slowly progressing attachment loss, sometimes with periods of more rapid progression.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010103 "Periodontitis that invovles slowly progressing attachment loss, sometimes with periods of more rapid progression."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010103 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010103 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010103 "2025-06-16T18:42:35Z"^^xsd:dateTime)
@@ -8043,7 +8043,7 @@ SubClassOf(obo:OHD_0010103 ObjectSomeValuesFrom(obo:RO_0000056 obo:OGMS_0000064)
 
 # Class: obo:OHD_0010104 (periodontal disease due to chronic periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010104 "Periodontal disease resulting from chronic periodontitis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010104 "Periodontal disease resulting from chronic periodontitis."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010104 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010104 "2025-06-16T18:44:27Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010104 "periodontal disease due to chronic periodontitis"@en)
@@ -8052,7 +8052,7 @@ SubClassOf(obo:OHD_0010104 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010103))
 
 # Class: obo:OHD_0010105 (periodontal pain due to chronic periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010105 "Periodontal pain due to periodontal disease resulting from chronic periodontitis. Chronic periodontitis is characterized by slowly progressing attachment loss, sometimes with periods of more rapid progression.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010105 "Periodontal pain due to periodontal disease resulting from chronic periodontitis. Chronic periodontitis is characterized by slowly progressing attachment loss, sometimes with periods of more rapid progression."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010105 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010105 "1.1.2.1.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010105 <https://orcid.org/0009-0003-5583-4731>)
@@ -8064,7 +8064,7 @@ SubClassOf(obo:OHD_0010105 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010103))
 
 # Class: obo:OHD_0010106 (pulpal pain due to placement of a restoration)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010106 "Pulpal pain due to a dental procedure involving a recent placement of a direct or indirect dental restoration in the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010106 "Pulpal pain due to a dental procedure involving a recent placement of a direct or indirect dental restoration in the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010106 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010106 "1.1.1.1.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010106 <https://orcid.org/0009-0003-5583-4731>)
@@ -8076,7 +8076,7 @@ SubClassOf(obo:OHD_0010106 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000004))
 
 # Class: obo:OHD_0010107 (reversible pulpitis due to tooth crack without evidence of missing tooth substance)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010107 "Reversible pulpitits due to a tooth crack without evidence of missing tooth substances.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010107 "Reversible pulpitits due to a tooth crack without evidence of missing tooth substances."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010107 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010107 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010107 "2025-06-23T20:17:04Z"^^xsd:dateTime)
@@ -8086,7 +8086,7 @@ SubClassOf(obo:OHD_0010107 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010095))
 
 # Class: obo:OHD_0010108 (pulpal pain due to reversible pulpitis resulting from tooth crack without evidence of missing tooth substance.)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010108 "Pulpal pain caused by reversible pulpitis due to infection of dentin because of a crack or incomplete fracture of the affected tooth, involving the enamel or enamel and dentin. Has evidence of at least one of the following: sharp pain upon biting, pain on release of occlusal biting pressure or external application of force, and cold hypersensitivity.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010108 "Pulpal pain caused by reversible pulpitis due to infection of dentin because of a crack or incomplete fracture of the affected tooth, involving the enamel or enamel and dentin. Has evidence of at least one of the following: sharp pain upon biting, pain on release of occlusal biting pressure or external application of force, and cold hypersensitivity."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010108 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010108 "1.1.1.3.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010108 <https://orcid.org/0009-0003-5583-4731>)
@@ -8098,7 +8098,7 @@ SubClassOf(obo:OHD_0010108 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010107))
 
 # Class: obo:OHD_0010109 (aggressive periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010109 "Periodontitis characterized by rapidly progressing attachment loss and, sometimes, onset at a young age.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010109 "Periodontitis characterized by rapidly progressing attachment loss and, sometimes, onset at a young age."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010109 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010109 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010109 "2025-06-17T18:35:54Z"^^xsd:dateTime)
@@ -8107,7 +8107,7 @@ SubClassOf(obo:OHD_0010109 obo:OHD_0010070)
 
 # Class: obo:OHD_0010110 (periodontal disease due to aggressive periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010110 "Periodontal disease resulting from aggressive periodontitis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010110 "Periodontal disease resulting from aggressive periodontitis."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010110 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010110 "2025-06-17T18:38:52Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010110 "periodontal disease due to aggressive periodontitis"@en)
@@ -8116,7 +8116,7 @@ SubClassOf(obo:OHD_0010110 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010109))
 
 # Class: obo:OHD_0010111 (periodontal pain due to aggressive periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010111 "Periodontal pain due to periodontal disease resulitng from aggressive periodontitis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010111 "Periodontal pain due to periodontal disease resulitng from aggressive periodontitis."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010111 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010111 "1.1.2.1.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010111 <https://orcid.org/0009-0003-5583-4731>)
@@ -8128,7 +8128,7 @@ SubClassOf(obo:OHD_0010111 ObjectSomeValuesFrom(obo:BFO_0000055 obo:OHD_0010110)
 
 # Class: obo:OHD_0010112 (necrotizing ulcerative periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010112 "Periodontitis that causes soft tissue destruction, as well as loss of attachment and alveolar bone.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010112 "Periodontitis that causes soft tissue destruction, as well as loss of attachment and alveolar bone."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010112 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010112 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010112 "2025-06-17T18:44:54Z"^^xsd:dateTime)
@@ -8137,7 +8137,7 @@ SubClassOf(obo:OHD_0010112 obo:OHD_0010070)
 
 # Class: obo:OHD_0010113 (periodontal disease due to necrotizing ulcerative periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010113 "Periodontal disease resulting from necrotizing ulcerative periodontitis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010113 "Periodontal disease resulting from necrotizing ulcerative periodontitis."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010113 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010113 "2025-06-17T18:50:48Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010113 "periodontal disease due to necrotizing ulcerative periodontitis"@en)
@@ -8146,7 +8146,7 @@ SubClassOf(obo:OHD_0010113 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010112))
 
 # Class: obo:OHD_0010114 (periodontal pain due to necrotizing ulcerative periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010114 "Periodontal pain due to periodontal disease resulting from necrotizing ulcerative periodontitis, with the development of pain within hours to days of onset of the ulcerations.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010114 "Periodontal pain due to periodontal disease resulting from necrotizing ulcerative periodontitis, with the development of pain within hours to days of onset of the ulcerations."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010114 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010114 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010114 "2025-06-17T18:55:03Z"^^xsd:dateTime)
@@ -8158,7 +8158,7 @@ SubClassOf(obo:OHD_0010114 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010113))
 
 # Class: obo:OHD_0010115 (gingival disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010115 "A mouth disorder that is part of the gingival tissue.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010115 "A mouth disorder that is part of the gingival tissue."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010115 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010115 "2025-06-18T17:06:36Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010115 "gingival disorder"@en)
@@ -8167,7 +8167,7 @@ SubClassOf(obo:OHD_0010115 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_00018
 
 # Class: obo:OHD_0010116 (oral mucosal disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010116 "A mouth disorder that is part of the mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010116 "A mouth disorder that is part of the mucosa."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010116 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010116 "2025-06-18T17:16:52Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010116 "oral mucosal disorder"@en)
@@ -8176,7 +8176,7 @@ SubClassOf(obo:OHD_0010116 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_00037
 
 # Class: obo:OHD_0010117 (periodontal disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010117 "A mouth disorder that is part of the periodontium.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010117 "A mouth disorder that is part of the periodontium."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010117 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010117 "2025-06-18T17:20:17Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010117 "periodontal disorder"@en)
@@ -8185,7 +8185,7 @@ SubClassOf(obo:OHD_0010117 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_00017
 
 # Class: obo:OHD_0010118 (primary temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010118 "Temporomandibular pain localized to the temporomandibular joint (TMJ), occurring at rest or during jaw movement or palpation, with no known causative disorder. The diagnosis corresponds fully to the DC/TMD diagnosis temporomandibular joint pain.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010118 "Temporomandibular pain localized to the temporomandibular joint (TMJ), occurring at rest or during jaw movement or palpation, with no known causative disorder. The diagnosis corresponds fully to the DC/TMD diagnosis temporomandibular joint pain."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010118 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010118 "3.1"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010118 <https://orcid.org/0009-0003-5583-4731>)
@@ -8196,7 +8196,7 @@ SubClassOf(obo:OHD_0010118 obo:OHD_0010004)
 
 # Class: obo:OHD_0010119 (acute primary temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010119 "Primary temporomandibular joint pain with onset within the last 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010119 "Primary temporomandibular joint pain with onset within the last 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010119 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010119 "3.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010119 <https://orcid.org/0009-0003-5583-4731>)
@@ -8208,7 +8208,7 @@ SubClassOf(obo:OHD_0010119 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010140))
 
 # Class: obo:OHD_0010120 (chronic primary temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010120 "Primary temporomandibular pain with onset more than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010120 "Primary temporomandibular pain with onset more than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010120 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010120 "3.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010120 <https://orcid.org/0009-0003-5583-4731>)
@@ -8220,7 +8220,7 @@ SubClassOf(obo:OHD_0010120 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010141))
 
 # Class: obo:OHD_0010121 (chronic infrequent primary temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010121 "Chronic primary temporomandibular joint pain occuring less than one day a month.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010121 "Chronic primary temporomandibular joint pain occuring less than one day a month."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010121 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010121 "3.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010121 <https://orcid.org/0009-0003-5583-4731>)
@@ -8232,7 +8232,7 @@ SubClassOf(obo:OHD_0010121 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010221))
 
 # Class: obo:OHD_0010122 (chronic frequent primary temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010122 "Chronic primary temporomandibular joint pain occuring one to 14 days a month for an avergae of more than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010122 "Chronic primary temporomandibular joint pain occuring one to 14 days a month for an avergae of more than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010122 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010122 "3.1.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010122 <https://orcid.org/0009-0003-5583-4731>)
@@ -8244,7 +8244,7 @@ SubClassOf(obo:OHD_0010122 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010220))
 
 # Class: obo:OHD_0010123 (chronic frequent primary temporomandibular joint pain without pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010123 "Chronic frequent primary temporomandibular joint pain with temporomandibular joint palpation pain localizaed to the immediate site of palpatation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010123 "Chronic frequent primary temporomandibular joint pain with temporomandibular joint palpation pain localizaed to the immediate site of palpatation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010123 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010123 "3.1.2.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010123 <https://orcid.org/0009-0003-5583-4731>)
@@ -8256,7 +8256,7 @@ SubClassOf(obo:OHD_0010123 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010223))
 
 # Class: obo:OHD_0010124 (chronic frequent primary temporomandibular joint pain with pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010124 "Chronic frequent primary temporomandibular joint pain with TMJ palpatation beyond the area of the joint.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010124 "Chronic frequent primary temporomandibular joint pain with TMJ palpatation beyond the area of the joint."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010124 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010124 "3.1.2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010124 <https://orcid.org/0009-0003-5583-4731>)
@@ -8268,7 +8268,7 @@ SubClassOf(obo:OHD_0010124 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010222))
 
 # Class: obo:OHD_0010125 (chronic highly frequent primary temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010125 "Chronic primary temporomandibular joint pain occuring on more than 15 days a month on average for more than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010125 "Chronic primary temporomandibular joint pain occuring on more than 15 days a month on average for more than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010125 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010125 "3.1.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010125 <https://orcid.org/0009-0003-5583-4731>)
@@ -8280,7 +8280,7 @@ SubClassOf(obo:OHD_0010125 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010226))
 
 # Class: obo:OHD_0010126 (chronic highly frequent primary temporomandibular joint pain without pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010126 "Chronic highly frequent primary temporomandibular joint pain on temporomandibular joint palpation localized to the immediate site of palpation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010126 "Chronic highly frequent primary temporomandibular joint pain on temporomandibular joint palpation localized to the immediate site of palpation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010126 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010126 "3.1.2.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010126 <https://orcid.org/0009-0003-5583-4731>)
@@ -8292,7 +8292,7 @@ SubClassOf(obo:OHD_0010126 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010229))
 
 # Class: obo:OHD_0010127 (chronic highly frequent primary temporomandibular joint pain with pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010127 "Chronic highly frequent primary temporomandibular joint pain on temporomandibular joint palpation beyond the area of the joint.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010127 "Chronic highly frequent primary temporomandibular joint pain on temporomandibular joint palpation beyond the area of the joint."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010127 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010127 "3.1.2.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010127 <https://orcid.org/0009-0003-5583-4731>)
@@ -8304,7 +8304,7 @@ SubClassOf(obo:OHD_0010127 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010230))
 
 # Class: obo:OHD_0010128 (secondary temporomandibular joint pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010128 "Pain localized to the temporomandibular joint (TMJ) and caused by another identified disorder, such as inflammation (due, for example, to trauma, infection, crystal deposition or autoimmune disorder), sensitization of the tissues, structural changes (such as osteoarthrosis, disc displacement or subluxation) or injury.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010128 "Pain localized to the temporomandibular joint (TMJ) and caused by another identified disorder, such as inflammation (due, for example, to trauma, infection, crystal deposition or autoimmune disorder), sensitization of the tissues, structural changes (such as osteoarthrosis, disc displacement or subluxation) or injury."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010128 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010128 "3.2"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010128 <https://orcid.org/0009-0003-5583-4731>)
@@ -8315,7 +8315,7 @@ SubClassOf(obo:OHD_0010128 obo:OHD_0010004)
 
 # Class: obo:OHD_0010129 (trigeminal neuralgic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010129 "Orofacial pain experienced as unilateral brief electric shock-like pains, abrupt in onset and termination, limited to the distribution of one or more divisions of the trigeminal nerve and triggered by innocuous stimuli.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010129 "Orofacial pain experienced as unilateral brief electric shock-like pains, abrupt in onset and termination, limited to the distribution of one or more divisions of the trigeminal nerve and triggered by innocuous stimuli."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010129 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010129 "4.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010129 <https://orcid.org/0009-0002-7282-0836>)
@@ -8331,7 +8331,7 @@ SubClassOf(obo:OHD_0010129 obo:OHD_0010059)
 
 # Class: obo:OHD_0010130 (classic trigeminal neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010130 "Trigeminal neuralgia developing without apparent cause other than neurovascular compression.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010130 "Trigeminal neuralgia developing without apparent cause other than neurovascular compression."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010130 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010130 "4.1.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010130 <https://orcid.org/0009-0003-5583-4731>)
@@ -8342,7 +8342,7 @@ SubClassOf(obo:OHD_0010130 obo:OHD_0010129)
 
 # Class: obo:OHD_0010131 (secondary trigeminal neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010131 "Trigeminal neuralgia caused by an underlying disease. Clinical examination shows sensory changes in a substantial percentage of these patients.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010131 "Trigeminal neuralgia caused by an underlying disease. Clinical examination shows sensory changes in a substantial percentage of these patients."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010131 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010131 "4.1.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010131 <https://orcid.org/0009-0003-5583-4731>)
@@ -8353,7 +8353,7 @@ SubClassOf(obo:OHD_0010131 obo:OHD_0010129)
 
 # Class: obo:OHD_0010132 (pain due to lesion or disease of the glossopharyngeal nerve)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010132 "Orofacial pain attributed to lesion or disease of the glossopharyngeal nerve.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010132 "Orofacial pain attributed to lesion or disease of the glossopharyngeal nerve."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010132 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010132 "4.2"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010132 <https://orcid.org/0009-0003-5583-4731>)
@@ -8366,7 +8366,7 @@ SubClassOf(obo:OHD_0010132 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010252))
 
 # Class: obo:OHD_0010133 (glossopharyngeal neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010133 "A disorder characterized by unilateral brief stabbing pain, abrupt in onset and termination, in the distributions not only of the glossopharyngeal nerve but also of the auricular and pharyngeal branches of the vagus nerve. Pain is experienced in the ear, base of the tongue, tonsillar fossa and/or beneath the angle of the jaw. It is commonly provoked by swallowing, talking or coughing and may remit and relapse in the fashion of Trigeminal neuralgia.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010133 "A disorder characterized by unilateral brief stabbing pain, abrupt in onset and termination, in the distributions not only of the glossopharyngeal nerve but also of the auricular and pharyngeal branches of the vagus nerve. Pain is experienced in the ear, base of the tongue, tonsillar fossa and/or beneath the angle of the jaw. It is commonly provoked by swallowing, talking or coughing and may remit and relapse in the fashion of Trigeminal neuralgia."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010133 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010133 "4.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010133 <https://orcid.org/0009-0003-5583-4731>)
@@ -8377,7 +8377,7 @@ SubClassOf(obo:OHD_0010133 obo:OHD_0010132)
 
 # Class: obo:OHD_0010134 (classical glossopharyngeal neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010134 "Glossopharyngeal neuralgia with recurrent paroxysms of unilateral pain with the demonstration of magnetic resonance imaging.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010134 "Glossopharyngeal neuralgia with recurrent paroxysms of unilateral pain with the demonstration of magnetic resonance imaging."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010134 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010134 "4.2.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010134 <https://orcid.org/0009-0003-5583-4731>)
@@ -8388,7 +8388,7 @@ SubClassOf(obo:OHD_0010134 obo:OHD_0010133)
 
 # Class: obo:OHD_0010135 (secondary glossopharyngeal neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010135 "Glossopharyngeal neuralgia caused by an underlying disease.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010135 "Glossopharyngeal neuralgia caused by an underlying disease."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010135 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010135 "4.2.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010135 <https://orcid.org/0009-0003-5583-4731>)
@@ -8399,7 +8399,7 @@ SubClassOf(obo:OHD_0010135 obo:OHD_0010133)
 
 # Class: obo:OHD_0010136 (idiopathic glossopharyngeal neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010136 "Glossopharyngeal neuralgia with recurrent paroxysms of unilateral pain without neurovascular compression or an underlying disease know to cause secondary glossopharyngeal neuralgia.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010136 "Glossopharyngeal neuralgia with recurrent paroxysms of unilateral pain without neurovascular compression or an underlying disease know to cause secondary glossopharyngeal neuralgia."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010136 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010136 "4.2.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010136 <https://orcid.org/0009-0003-5583-4731>)
@@ -8411,7 +8411,7 @@ SubClassOf(obo:OHD_0010136 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010251))
 
 # Class: obo:OHD_0010137 (pulpal pain due to hyperocclusion or hyperarticulation following dental restorative procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010137 "Pulpal pain due to a dental procedure involving a restorative procedure which has caused the affected tooth to be in hyperocclusion or hyperarticulation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010137 "Pulpal pain due to a dental procedure involving a restorative procedure which has caused the affected tooth to be in hyperocclusion or hyperarticulation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010137 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010137 "1.1.1.1.3.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010137 <https://orcid.org/0009-0003-5583-4731>)
@@ -8422,7 +8422,7 @@ SubClassOf(obo:OHD_0010137 obo:OHD_0010078)
 
 # Class: obo:OHD_0010138 (pulpal pain due to hyperocclusion following dental restorative procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010138 "Pulpal pain due to a dental procedure involving a restorative procedure which has caused the affected tooth to be in hyperocclusion.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010138 "Pulpal pain due to a dental procedure involving a restorative procedure which has caused the affected tooth to be in hyperocclusion."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010138 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010138 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010138 "2025-06-24T15:29:21Z"^^xsd:dateTime)
@@ -8433,7 +8433,7 @@ SubClassOf(obo:OHD_0010138 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010145))
 
 # Class: obo:OHD_0010139 (pulpal pain due to hyperarticulation following dental restorative procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010139 "Pulpal pain due to a dental procedure involving a restorative procedure which has caused the affected tooth to be in hyperarticulation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010139 "Pulpal pain due to a dental procedure involving a restorative procedure which has caused the affected tooth to be in hyperarticulation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010139 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010139 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010139 "2025-06-24T15:29:40Z"^^xsd:dateTime)
@@ -8444,7 +8444,7 @@ SubClassOf(obo:OHD_0010139 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010146))
 
 # Class: obo:OHD_0010140 (acute pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010140 "Pain that is onset within the last 3 months")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010140 "Pain that is onset within the last 3 months"@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010140 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010140 "2025-06-25T18:14:29Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010140 "acute pain"@en)
@@ -8452,7 +8452,7 @@ SubClassOf(obo:OHD_0010140 obo:OGMS_0000085)
 
 # Class: obo:OHD_0010141 (chronic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010141 "Pain that is onset for more than three months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010141 "Pain that is onset for more than three months."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010141 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010141 "2025-06-25T18:15:03Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010141 "chronic pain"@en)
@@ -8460,7 +8460,7 @@ SubClassOf(obo:OHD_0010141 obo:OGMS_0000085)
 
 # Class: obo:OHD_0010142 (orofacial pain due to lesion or disease of the cranial nerves)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010142 "Orofacial pain due to lesisoin or disease of the cranial nerves.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010142 "Orofacial pain due to lesisoin or disease of the cranial nerves."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010142 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010142 "4"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010142 <https://orcid.org/0009-0003-5583-4731>)
@@ -8471,7 +8471,7 @@ SubClassOf(obo:OHD_0010142 obo:OHD_0010000)
 
 # Class: obo:OHD_0010143 (hyperocclusion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010143 "A tooth disorder resulting in a tooth making excessive contact with an opposing tooth, enroaching on the intercostal space.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010143 "A tooth disorder resulting in a tooth making excessive contact with an opposing tooth, enroaching on the intercostal space."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010143 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010143 "2025-06-25T18:29:47Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010143 "hyperocclusion"@en)
@@ -8486,7 +8486,7 @@ SubClassOf(obo:OHD_0010144 obo:OHD_0000260)
 
 # Class: obo:OHD_0010145 (hyperocclusion following dental restorative procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010145 "Hyperocclusion occuring after a dental restorative procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010145 "Hyperocclusion occuring after a dental restorative procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010145 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010145 "2025-06-25T18:49:54Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010145 "hyperocclusion following dental restorative procedure"@en)
@@ -8495,7 +8495,7 @@ SubClassOf(obo:OHD_0010145 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000004))
 
 # Class: obo:OHD_0010146 (hyperarticulation following dental restorative procedure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010146 "Hyperarticulation occuring after a dental restoative procedure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010146 "Hyperarticulation occuring after a dental restoative procedure."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010146 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010146 "2025-06-25T18:50:29Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010146 "hyperarticulation following dental restorative procedure"@en)
@@ -8504,7 +8504,7 @@ SubClassOf(obo:OHD_0010146 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000004))
 
 # Class: obo:OHD_0010147 (pulpal pain due to extensive removal of dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010147 "Pulpal pain due to a dental procedure resulting in the removal of dentin from the affected tooth, which was wide, deep, or both.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010147 "Pulpal pain due to a dental procedure resulting in the removal of dentin from the affected tooth, which was wide, deep, or both."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010147 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010147 "1.1.1.1.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010147 <https://orcid.org/0009-0003-5583-4731>)
@@ -8515,7 +8515,7 @@ SubClassOf(obo:OHD_0010147 obo:OHD_0010078)
 
 # Class: obo:OHD_0010148 (dental injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010148 "An injury occuring within the the tooth pulp, periodontium or gingivae.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010148 "An injury occuring within the the tooth pulp, periodontium or gingivae."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010148 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010148 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010148 "2025-06-25T18:59:05Z"^^xsd:dateTime)
@@ -8525,7 +8525,7 @@ SubClassOf(obo:OHD_0010148 ObjectSomeValuesFrom(obo:BFO_0000066 obo:UBERON_00001
 
 # Class: obo:OHD_0010149 (dental hard tissue fracture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010149 "A tooth fracture occuring within the enamel, root cementum, or dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010149 "A tooth fracture occuring within the enamel, root cementum, or dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010149 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010149 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010149 "2025-06-25T19:11:48Z"^^xsd:dateTime)
@@ -8534,7 +8534,7 @@ SubClassOf(obo:OHD_0010149 obo:OHD_0000277)
 
 # Class: obo:OHD_0010150 (dental hard tissue fracture without pulp exposure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010150 "A dental hard tissue fracture that does not involve the exposure of dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010150 "A dental hard tissue fracture that does not involve the exposure of dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010150 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010150 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010150 "2025-06-25T19:13:46Z"^^xsd:dateTime)
@@ -8543,7 +8543,7 @@ SubClassOf(obo:OHD_0010150 obo:OHD_0010149)
 
 # Class: obo:OHD_0010151 (irreversible pulpitis due to dental hard tissue fracture without pulp exposure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010151 "Irreversible pulpitis due to a dental hard tissue fracture without pulp exposure.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010151 "Irreversible pulpitis due to a dental hard tissue fracture without pulp exposure."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010151 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010151 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010151 "2025-06-25T19:15:09Z"^^xsd:dateTime)
@@ -8553,7 +8553,7 @@ SubClassOf(obo:OHD_0010151 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010150))
 
 # Class: obo:OHD_0010152 (pulpal pain due to irreversible pulpitis resulting from a dental hard-tissue fracture without pulp exposure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010152 "Pulpal pain attributed to irreversible pulpitis due to infection of dentin with evidence of a fracture in one of the following: enamel and dentin (uncomplicated crown fracture),  root cementum and dentin (uncomplicated root fracture), or enamel, root cementum and dentin (uncomplicated crown-root fracture).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010152 "Pulpal pain attributed to irreversible pulpitis due to infection of dentin with evidence of a fracture in one of the following: enamel and dentin (uncomplicated crown fracture),  root cementum and dentin (uncomplicated root fracture), or enamel, root cementum and dentin (uncomplicated crown-root fracture)."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010152 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010152 "1.1.1.3.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010152 <https://orcid.org/0009-0003-5583-4731>)
@@ -8565,7 +8565,7 @@ SubClassOf(obo:OHD_0010152 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010151))
 
 # Class: obo:OHD_0010153 (reversible pulpitis due to tooth crack)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010153 "Reversible pulpitis due to dentin infection occuring because of a tooth crack")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010153 "Reversible pulpitis due to dentin infection occuring because of a tooth crack"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010153 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010153 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010153 "2025-06-25T19:22:26Z"^^xsd:dateTime)
@@ -8575,7 +8575,7 @@ SubClassOf(obo:OHD_0010153 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010094))
 
 # Class: obo:OHD_0010154 (irreversible pulpitis due to dental hard tissue fracture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010154 "Irreversible pulpitis due to dentin infection occuring becayse of a dental hard tissude fracture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010154 "Irreversible pulpitis due to dentin infection occuring becayse of a dental hard tissude fracture."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010154 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010154 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010154 "2025-06-25T19:23:53Z"^^xsd:dateTime)
@@ -8585,7 +8585,7 @@ SubClassOf(obo:OHD_0010154 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010149))
 
 # Class: obo:OHD_0010155 (reversible pulpitis due to dental hard tissue fracture)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010155 "Reversible pulpitis due to dentin infection resulting from a dental hard tissue fracture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010155 "Reversible pulpitis due to dentin infection resulting from a dental hard tissue fracture."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010155 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010155 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010155 "2025-06-25T19:26:50Z"^^xsd:dateTime)
@@ -8594,7 +8594,7 @@ SubClassOf(obo:OHD_0010155 obo:OHD_0010066)
 
 # Class: obo:OHD_0010156 (dental hard tissue fracture with exposed dentin)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010156 "Dental hard tissue fracture involving the enamel, root cementum, dentin, or any combination thereof and resulting in exposed dentin.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010156 "Dental hard tissue fracture involving the enamel, root cementum, dentin, or any combination thereof and resulting in exposed dentin."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010156 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010156 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010156 "2025-06-25T19:30:44Z"^^xsd:dateTime)
@@ -8604,7 +8604,7 @@ SubClassOf(obo:OHD_0010156 ObjectSomeValuesFrom(obo:BFO_0000051 obo:OHD_0000410)
 
 # Class: obo:OHD_0010157 (reversible pulpitis due to dental caries)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010157 "Reversible pulpitis due to dentin infection occuring because of dental caries.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010157 "Reversible pulpitis due to dentin infection occuring because of dental caries."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010157 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010157 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010157 "2025-06-25T19:34:08Z"^^xsd:dateTime)
@@ -8614,7 +8614,7 @@ SubClassOf(obo:OHD_0010157 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000031))
 
 # Class: obo:OHD_0010158 (irreversible pulpitis due to dental caries)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010158 "Irreversible pulpitis due to dentin infection occuring because of dental caries.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010158 "Irreversible pulpitis due to dentin infection occuring because of dental caries."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010158 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010158 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010158 "2025-06-25T19:35:31Z"^^xsd:dateTime)
@@ -8624,7 +8624,7 @@ SubClassOf(obo:OHD_0010158 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0000031))
 
 # Class: obo:OHD_0010159 (irreversible pulpitis due to tooth crack)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010159 "Irreversible pulpitis due to a dentin infection occuring because of a tooth crack.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010159 "Irreversible pulpitis due to a dentin infection occuring because of a tooth crack."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010159 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010159 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010159 "2025-06-25T19:38:43Z"^^xsd:dateTime)
@@ -8634,7 +8634,7 @@ SubClassOf(obo:OHD_0010159 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010094))
 
 # Class: obo:OHD_0010160 (irreversible pulpitis due to tooth crack without evidence of missing tooth substance)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010160 "Irreversible pulpitits due to a tooth crack without evidence of missing tooth substances.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010160 "Irreversible pulpitits due to a tooth crack without evidence of missing tooth substances."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010160 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010160 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010160 "2025-06-25T19:39:40Z"^^xsd:dateTime)
@@ -8644,7 +8644,7 @@ SubClassOf(obo:OHD_0010160 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010095))
 
 # Class: obo:OHD_0010161 (pulpal pain due to irreversible pulpitis resulting from tooth crack without evidence of missing tooth substance)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010161 "Pulpal pain attributed to irreversible pulpitis due to infection of dentin because of a crack or incompletel fracture in the enamel or enamel dentin, along with at least one of the following: sharp pain upon biting, pain on release of occlusal biting pressure or external application of force, and cold hypersensitivity.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010161 "Pulpal pain attributed to irreversible pulpitis due to infection of dentin because of a crack or incompletel fracture in the enamel or enamel dentin, along with at least one of the following: sharp pain upon biting, pain on release of occlusal biting pressure or external application of force, and cold hypersensitivity."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010161 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010161 "1.1.1.3.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010161 <https://orcid.org/0009-0003-5583-4731>)
@@ -8656,7 +8656,7 @@ SubClassOf(obo:OHD_0010161 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010160))
 
 # Class: obo:OHD_0010162 (dental hard tissue fracture with pulp exposure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010162 "A dental hard tissue fracture that does involve the exposure of dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010162 "A dental hard tissue fracture that does involve the exposure of dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010162 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010162 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010162 "2025-06-25T19:55:44Z"^^xsd:dateTime)
@@ -8665,7 +8665,7 @@ SubClassOf(obo:OHD_0010162 obo:OHD_0010149)
 
 # Class: obo:OHD_0010163 (irreversible pulpitis due to dental hard tissue fracture with pulp exposure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010163 "Irreversible pulpitis due to dental pulp infection uccring because of a dental hard tissue fracture involving the exposure of dental pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010163 "Irreversible pulpitis due to dental pulp infection uccring because of a dental hard tissue fracture involving the exposure of dental pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010163 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010163 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010163 "2025-06-25T19:57:58Z"^^xsd:dateTime)
@@ -8675,7 +8675,7 @@ SubClassOf(obo:OHD_0010163 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010162))
 
 # Class: obo:OHD_0010164 (pulpal pain due to irreversible pulpitis resulting from a dental hard-tissue fracture with pulp exposure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010164 "Pulpal pain attirbuted to irreversible pulpitis due to infection of the dental pulp with evidence of a fracture in one of the following: enamel and dentin (uncomplicated crown fracture),  root cementum and dentin (uncomplicated root fracture), or enamel, root cementum and dentin (uncomplicated crown-root fracture) along with pain that has developed in close temporal relation to the fracture with pain developing in close temporal relation to the fracture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010164 "Pulpal pain attirbuted to irreversible pulpitis due to infection of the dental pulp with evidence of a fracture in one of the following: enamel and dentin (uncomplicated crown fracture),  root cementum and dentin (uncomplicated root fracture), or enamel, root cementum and dentin (uncomplicated crown-root fracture) along with pain that has developed in close temporal relation to the fracture with pain developing in close temporal relation to the fracture."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010164 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010164 "1.1.1.3.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010164 <https://orcid.org/0009-0003-5583-4731>)
@@ -8687,7 +8687,7 @@ SubClassOf(obo:OHD_0010164 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010163))
 
 # Class: obo:OHD_0010165 (external cervical root resorption process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010165 "A pathological bodily process that abnormally occurs when dentin is resorbed by osteoclastic activity.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010165 "A pathological bodily process that abnormally occurs when dentin is resorbed by osteoclastic activity."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010165 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010165 "2025-06-26T18:19:19Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010165 "external cervical root resorption process"@en)
@@ -8695,7 +8695,7 @@ SubClassOf(obo:OHD_0010165 obo:OGMS_0000061)
 
 # Class: obo:OHD_0010166 (pulpal pain due to pulpitis resulting from an external cervical root resorption)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010166 "Pulpal pain attributed to pulpitis with an external cervical root resorption with pain that has developed in temporal relation to onset of the resorption.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010166 "Pulpal pain attributed to pulpitis with an external cervical root resorption with pain that has developed in temporal relation to onset of the resorption."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010166 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010166 "1.1.1.3.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010166 <https://orcid.org/0009-0003-5583-4731>)
@@ -8707,7 +8707,7 @@ SubClassOf(obo:OHD_0010166 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010165))
 
 # Class: obo:OHD_0010167 (periodontal pain due to hyperocclusion or hyperarticulation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010167 "Periodontal pain attributed to traumatically induced periodontal inflammation because of a change in occlusal conditions that has occurred, with resultant hyperocclusion or hyperarticulation identified by at least one of the following: primary contact affecting a tooth in occlusion or articulation or hypermobility of a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010167 "Periodontal pain attributed to traumatically induced periodontal inflammation because of a change in occlusal conditions that has occurred, with resultant hyperocclusion or hyperarticulation identified by at least one of the following: primary contact affecting a tooth in occlusion or articulation or hypermobility of a tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010167 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010167 "1.1.2.1.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010167 <https://orcid.org/0009-0003-5583-4731>)
@@ -8718,7 +8718,7 @@ SubClassOf(obo:OHD_0010167 obo:OHD_0010073)
 
 # Class: obo:OHD_0010168 (periodontal pain due to hyperocclusion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010168 "Periodontal pain attributed to traumatically induced periodontal inflammation because of a change in occlusal conditions that has occurred, with resultant hyperocclusion identified by primary contact affecting a tooth in occlusion or hypermobility of a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010168 "Periodontal pain attributed to traumatically induced periodontal inflammation because of a change in occlusal conditions that has occurred, with resultant hyperocclusion identified by primary contact affecting a tooth in occlusion or hypermobility of a tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010168 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010168 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010168 "2025-06-26T18:26:36Z"^^xsd:dateTime)
@@ -8729,7 +8729,7 @@ SubClassOf(obo:OHD_0010168 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010143))
 
 # Class: obo:OHD_0010169 (periodontal pain due to hyperarticulation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010169 "Periodontal pain attributed to traumatically induced periodontal inflammation because of a change in occlusal conditions that has occurred, with resultant hyperarticulation identified by primary contact affecting a tooth in articulation or hypermobility of a tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010169 "Periodontal pain attributed to traumatically induced periodontal inflammation because of a change in occlusal conditions that has occurred, with resultant hyperarticulation identified by primary contact affecting a tooth in articulation or hypermobility of a tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010169 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010169 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010169 "2025-06-26T18:26:45Z"^^xsd:dateTime)
@@ -8740,7 +8740,7 @@ SubClassOf(obo:OHD_0010169 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010144))
 
 # Class: obo:OHD_0010170 (periodontal pain due to accidental dental injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010170 "Periodontal pain attributed to traumatically induced periodontal inflammation because of accidental trauma with evidence of one of the following: concussion, subluxation, lateral luxation, intrusion, extrusion, avulsion, or root fracture.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010170 "Periodontal pain attributed to traumatically induced periodontal inflammation because of accidental trauma with evidence of one of the following: concussion, subluxation, lateral luxation, intrusion, extrusion, avulsion, or root fracture."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010170 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010170 "1.1.2.1.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010170 <https://orcid.org/0009-0003-5583-4731>)
@@ -8752,7 +8752,7 @@ SubClassOf(obo:OHD_0010170 ObjectSomeValuesFrom(obo:RO_0000057 obo:OHD_0010148))
 
 # Class: obo:OHD_0010171 (periodontal pain due to pulpal inflammation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010171 "Periodontal pain attributed to apical periodontitis due to endodontic disease because of pulpitis that has been diagnosed because of one of the following: evidence of dental disorder involving the affected tooth or vital pulp evidenced by response to pulp vitality testing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010171 "Periodontal pain attributed to apical periodontitis due to endodontic disease because of pulpitis that has been diagnosed because of one of the following: evidence of dental disorder involving the affected tooth or vital pulp evidenced by response to pulp vitality testing."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010171 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010171 "1.1.2.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010171 <https://orcid.org/0009-0003-5583-4731>)
@@ -8764,7 +8764,7 @@ SubClassOf(obo:OHD_0010171 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010060))
 
 # Class: obo:OHD_0010172 (endodontic infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010172 "An infectious disorer occuring within the tooth pulp.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010172 "An infectious disorer occuring within the tooth pulp."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010172 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010172 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010172 "2025-06-26T18:36:01Z"^^xsd:dateTime)
@@ -8774,7 +8774,7 @@ SubClassOf(obo:OHD_0010172 ObjectSomeValuesFrom(obo:BFO_0000066 obo:UBERON_00017
 
 # Class: obo:OHD_0010173 (periodontal pain due to endodontic infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010173 "Periodontal pain attributed to apical periodontitis due to endodontic disease because of partial or total pulp necrosis and endodontic infection that have been diagnosed by: non-vital pulp, evidenced by either: direct inspection, or non-response to pulp vitality testing or a previously debrided root canal or clinical or radiographic evidence of apical inflammation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010173 "Periodontal pain attributed to apical periodontitis due to endodontic disease because of partial or total pulp necrosis and endodontic infection that have been diagnosed by: non-vital pulp, evidenced by either: direct inspection, or non-response to pulp vitality testing or a previously debrided root canal or clinical or radiographic evidence of apical inflammation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010173 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010173 "1.1.2.1.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010173 <https://orcid.org/0009-0003-5583-4731>)
@@ -8786,7 +8786,7 @@ SubClassOf(obo:OHD_0010173 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010172))
 
 # Class: obo:OHD_0010174 (intraradicular endodontic infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010174 "An endodontic infection occuring within the root canal system of the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010174 "An endodontic infection occuring within the root canal system of the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010174 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010174 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010174 "2025-06-26T18:41:03Z"^^xsd:dateTime)
@@ -8795,7 +8795,7 @@ SubClassOf(obo:OHD_0010174 obo:OHD_0010172)
 
 # Class: obo:OHD_0010175 (periodontal pain due to intraradicular endodontic infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010175 "Periodontal pain due to endodontic infection resulting from to a tooth that has a root canal infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010175 "Periodontal pain due to endodontic infection resulting from to a tooth that has a root canal infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010175 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010175 "1.1.2.1.2.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010175 <https://orcid.org/0009-0003-5583-4731>)
@@ -8816,7 +8816,7 @@ SubClassOf(obo:OHD_0010176 obo:OHD_0010172)
 
 # Class: obo:OHD_0010177 (periodontal pain due to extraradicular endodontic infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010177 "Periodontal pain attributed to endodontic infection due to an extraradicular infection around one or more teeth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010177 "Periodontal pain attributed to endodontic infection due to an extraradicular infection around one or more teeth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010177 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010177 "1.1.2.1.2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010177 <https://orcid.org/0009-0003-5583-4731>)
@@ -8828,7 +8828,7 @@ SubClassOf(obo:OHD_0010177 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010176))
 
 # Class: obo:OHD_0010178 (periodontal pain due to periodontitis as a manifestation of a systemic disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010178 "Periodontal pain due to periodontal disease that results from a systematic disorder.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010178 "Periodontal pain due to periodontal disease that results from a systematic disorder."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010178 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010178 "1.1.2.1.3.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010178 <https://orcid.org/0009-0002-7282-0836>)
@@ -8842,7 +8842,7 @@ SubClassOf(obo:OHD_0010178 obo:OHD_0010102)
 
 # Class: obo:OHD_0010179 (periodontal pain due to genetic disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010179 "Periodontal pain due to periodontitis as a manifestion of a systematic genetic disorder. Genetic disorders which can result in periodontitis include familial and cyclic neutropenia, Down syndrome, leukocyte adhesion deficiency syndromes, Papillon–Lefèvre syndrome, Chediak–Higashi syndrome, histiocytosis syndromes, glycogen storage disease, infantile genetic agranulocytosis, Cohen syndrome, Ehler–Danlos syndrome (types IV and VIII), and hypophosphatasia.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010179 "Periodontal pain due to periodontitis as a manifestion of a systematic genetic disorder. Genetic disorders which can result in periodontitis include familial and cyclic neutropenia, Down syndrome, leukocyte adhesion deficiency syndromes, Papillon–Lefèvre syndrome, Chediak–Higashi syndrome, histiocytosis syndromes, glycogen storage disease, infantile genetic agranulocytosis, Cohen syndrome, Ehler–Danlos syndrome (types IV and VIII), and hypophosphatasia."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010179 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010179 "1.1.2.1.3.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010179 <https://orcid.org/0009-0002-7282-0836>)
@@ -8855,7 +8855,7 @@ SubClassOf(obo:OHD_0010179 ObjectSomeValuesFrom(obo:RO_0002410 obo:OGMS_0000047)
 
 # Class: obo:OHD_0010180 (hematological disorder due to infectious disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010180 "A hematological disorder caused by an infectious disorder.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010180 "A hematological disorder caused by an infectious disorder."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010180 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010180 "2025-06-26T18:58:07Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:comment obo:OHD_0010180 "The disorder might arise from an infection, but is not necessarily an infection.")
@@ -8864,7 +8864,7 @@ SubClassOf(obo:OHD_0010180 obo:OHD_0010187)
 
 # Class: obo:OHD_0010181 (periodontal pain due to haematological disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010181 "Periodontal pain due to periodontitis as a manifestation of a systematic haematological disorder. Haematological disorders which can result in periodontitis include acquired neutropenia and leukaemia.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010181 "Periodontal pain due to periodontitis as a manifestation of a systematic haematological disorder. Haematological disorders which can result in periodontitis include acquired neutropenia and leukaemia."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010181 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010181 "1.1.2.1.3.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010181 <https://orcid.org/0009-0002-7282-0836>)
@@ -8877,7 +8877,7 @@ SubClassOf(obo:OHD_0010181 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010180))
 
 # Class: obo:OHD_0010182 (periodontal pain due to periodontal abscess)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010182 "Periodontal pain due to periodontal disease resulting from either or both of the following: acute inflammation and loss of attatchement, or marginal and periradicular bone resorption.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010182 "Periodontal pain due to periodontal disease resulting from either or both of the following: acute inflammation and loss of attatchement, or marginal and periradicular bone resorption."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010182 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010182 "1.1.2.1.3.5")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010182 <https://orcid.org/0009-0003-5583-4731>)
@@ -8889,7 +8889,7 @@ SubClassOf(obo:OHD_0010182 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010183))
 
 # Class: obo:OHD_0010183 (periodontal abscess)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010183 "An infectious disorder occuring within the periodontium, characterized by a collection of pus.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010183 "An infectious disorder occuring within the periodontium, characterized by a collection of pus."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010183 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010183 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010183 "2025-06-26T19:07:48Z"^^xsd:dateTime)
@@ -8898,7 +8898,7 @@ SubClassOf(obo:OHD_0010183 obo:IDO_0000504)
 
 # Class: obo:OHD_0010184 (malignant lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010184 "A disorder characterized by the presence of malignant cells.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010184 "A disorder characterized by the presence of malignant cells."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010184 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010184 "2025-06-26T19:20:29Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010184 "malignant lesion"@en)
@@ -8906,7 +8906,7 @@ SubClassOf(obo:OHD_0010184 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010185 (gingival pain due to malignant lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010185 "Gingival pain due to a malignant lesion of the gingival tissues.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010185 "Gingival pain due to a malignant lesion of the gingival tissues."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010185 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010185 "1.1.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010185 <https://orcid.org/0009-0003-5583-4731>)
@@ -8918,7 +8918,7 @@ SubClassOf(obo:OHD_0010185 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010184))
 
 # Class: obo:OHD_0010186 (oral mucosal, salivary gland and jaw bone pains)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010186 "Pain due to a lesion or disorder affecting the non-dental oral and peri-oral tissues: the oral mucosa, the salivary glands and the jaw bone tissues.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010186 "Pain due to a lesion or disorder affecting the non-dental oral and peri-oral tissues: the oral mucosa, the salivary glands and the jaw bone tissues."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010186 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010186 "1.2"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010186 <https://orcid.org/0009-0003-5583-4731>)
@@ -8929,7 +8929,7 @@ SubClassOf(obo:OHD_0010186 obo:OHD_0010001)
 
 # Class: obo:OHD_0010187 (hematological disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010187 "A disorder of the hematopoietic system.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010187 "A disorder of the hematopoietic system."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010187 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010187 "2025-06-27T14:46:19Z"^^xsd:dateTime)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> obo:OHD_0010187 "haematological disorder")
@@ -8938,7 +8938,7 @@ SubClassOf(obo:OHD_0010187 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010188 (peri-implantitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010188 "A periodontal disorder resulting in inflammation surronding a dental implant.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010188 "A periodontal disorder resulting in inflammation surronding a dental implant."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010188 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010188 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010188 "2025-06-30T17:03:00Z"^^xsd:dateTime)
@@ -8948,7 +8948,7 @@ SubClassOf(obo:OHD_0010188 obo:OHD_0010070)
 
 # Class: obo:OHD_0010189 (infective peri-implantitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010189 "Peri-implantitis resulting from an infectious disorder.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010189 "Peri-implantitis resulting from an infectious disorder."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010189 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010189 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010189 "2025-06-30T17:05:04Z"^^xsd:dateTime)
@@ -8957,7 +8957,7 @@ SubClassOf(obo:OHD_0010189 obo:OHD_0010188)
 
 # Class: obo:OHD_0010190 (periodontal pain due to infective peri-implantitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010190 "Periodontal paind due to periodontitis, with the exception that it involves an implant and not a natural tooth, resulitng from a peri-implant infection with casuation from anatomical, functional, or temporal association.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010190 "Periodontal paind due to periodontitis, with the exception that it involves an implant and not a natural tooth, resulitng from a peri-implant infection with casuation from anatomical, functional, or temporal association."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010190 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010190 "1.1.2.1.5")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010190 <https://orcid.org/0009-0003-5583-4731>)
@@ -8969,7 +8969,7 @@ SubClassOf(obo:OHD_0010190 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010189))
 
 # Class: obo:OHD_0010191 (marginal periodontitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010191 "Periodontitis affecting the tissue of the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010191 "Periodontitis affecting the tissue of the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010191 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010191 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010191 "2025-06-30T17:08:45Z"^^xsd:dateTime)
@@ -8978,7 +8978,7 @@ SubClassOf(obo:OHD_0010191 obo:OHD_0010070)
 
 # Class: obo:OHD_0010192 (periodontal pain due to apical and marginal periodontitis resulting from combined endodontic infection and periodontal disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010192 "Periodontal pain due to periodontitis resulting from partial or total pulp necrosis or periodontal disease.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010192 "Periodontal pain due to periodontitis resulting from partial or total pulp necrosis or periodontal disease."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010192 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010192 "1.1.2.1.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010192 <https://orcid.org/0009-0003-5583-4731>)
@@ -8989,7 +8989,7 @@ SubClassOf(obo:OHD_0010192 obo:OHD_0010071)
 
 # Class: obo:OHD_0010193 (carious pulp exposure)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010193 "Exposed dental pulp resulting from dental caries.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010193 "Exposed dental pulp resulting from dental caries."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010193 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010193 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010193 "2025-06-30T17:27:09Z"^^xsd:dateTime)
@@ -8998,7 +8998,7 @@ SubClassOf(obo:OHD_0010193 obo:OHD_0010028)
 
 # Class: obo:OHD_0010194 (irreversible pulpitis due to carious pulp exposure and dental pulp infection)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010194 "Irreversible pulpitis due to infection of the dental pulp because of deep dental caries in the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010194 "Irreversible pulpitis due to infection of the dental pulp because of deep dental caries in the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010194 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010194 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010194 "2025-06-30T17:31:17Z"^^xsd:dateTime)
@@ -9007,7 +9007,7 @@ SubClassOf(obo:OHD_0010194 obo:OHD_0010098)
 
 # Class: obo:OHD_0010195 (pulpal pain due to irreversible pulpitis resulting from carious pulp exposure and infection of the pulp)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010195 "Pulpal pain due to irreversible pulpitis resulting from an infection of the dental pulp because of deep caries in the affected tooth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010195 "Pulpal pain due to irreversible pulpitis resulting from an infection of the dental pulp because of deep caries in the affected tooth."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010195 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010195 "1.1.1.3.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010195 <https://orcid.org/0009-0003-5583-4731>)
@@ -9019,7 +9019,7 @@ SubClassOf(obo:OHD_0010195 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010194))
 
 # Class: obo:OHD_0010196 (non-iatrogenic injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010196 "An injury that may be mechanical, thermal, or chemical, and accidental or non-accidental, inflicted by others or self-inflicted.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010196 "An injury that may be mechanical, thermal, or chemical, and accidental or non-accidental, inflicted by others or self-inflicted."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010196 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010196 "2025-06-30T17:45:08Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010196 "non-iatrogenic injury"@en)
@@ -9027,7 +9027,7 @@ SubClassOf(obo:OHD_0010196 obo:OGMS_0000102)
 
 # Class: obo:OHD_0010197 (oral mucosal inflammation due to non-iatrogenic injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010197 "Oral mucosal inflammation due to an injury that is non-iatrogenic.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010197 "Oral mucosal inflammation due to an injury that is non-iatrogenic."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010197 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010197 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010197 "2025-06-30T17:46:25Z"^^xsd:dateTime)
@@ -9037,7 +9037,7 @@ SubClassOf(obo:OHD_0010197 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010196))
 
 # Class: obo:OHD_0010198 (oral mucosal pain due to non-iatrogenic injury)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010198 "Oral mucosal pain due to oral mucosal inflammation resulting from non-iatrogenic injury.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010198 "Oral mucosal pain due to oral mucosal inflammation resulting from non-iatrogenic injury."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010198 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010198 "1.2.1.1.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010198 <https://orcid.org/0009-0003-5583-4731>)
@@ -9049,7 +9049,7 @@ SubClassOf(obo:OHD_0010198 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010197))
 
 # Class: obo:OHD_0010199 (oral mucosal inflammation due to radiation or chemotherapy)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010199 "Oral mucosal inflammation due to injury resulting from radiation or chemotherapy.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010199 "Oral mucosal inflammation due to injury resulting from radiation or chemotherapy."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010199 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010199 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010199 "2025-06-30T17:51:49Z"^^xsd:dateTime)
@@ -9058,7 +9058,7 @@ SubClassOf(obo:OHD_0010199 obo:OHD_0010056)
 
 # Class: obo:OHD_0010200 (oral mucosal pain due to radiation or chemotherapy)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010200 "Oral mucosal pain due to injury from radiation or chemotherapy")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010200 "Oral mucosal pain due to injury from radiation or chemotherapy"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010200 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010200 "1.2.1.1.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010200 <https://orcid.org/0009-0003-5583-4731>)
@@ -9070,7 +9070,7 @@ SubClassOf(obo:OHD_0010200 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010199))
 
 # Class: obo:OHD_0010201 (oral mucosal pain due to malignant lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010201 "Oral mucoal pain due to meoplasia of the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010201 "Oral mucoal pain due to meoplasia of the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010201 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010201 "1.2.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010201 <https://orcid.org/0009-0003-5583-4731>)
@@ -9082,7 +9082,7 @@ SubClassOf(obo:OHD_0010201 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010184))
 
 # Class: obo:OHD_0010202 (salivary gland disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010202 "A mouth disorder that is part of the salivary glands.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010202 "A mouth disorder that is part of the salivary glands."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010202 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010202 "2025-06-30T18:02:18Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010202 "salivary gland disorder"@en)
@@ -9091,7 +9091,7 @@ SubClassOf(obo:OHD_0010202 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_00010
 
 # Class: obo:OHD_0010203 (parotid disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010203 "A salivary gland disorder occuring within the parotid glands.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010203 "A salivary gland disorder occuring within the parotid glands."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010203 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010203 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010203 "2025-06-30T18:03:40Z"^^xsd:dateTime)
@@ -9100,7 +9100,7 @@ SubClassOf(obo:OHD_0010203 obo:OHD_0010202)
 
 # Class: obo:OHD_0010204 (parotitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010204 "A parotid disorder involving inflammation of the parotid glands.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010204 "A parotid disorder involving inflammation of the parotid glands."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010204 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010204 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010204 "2025-06-30T18:06:41Z"^^xsd:dateTime)
@@ -9109,7 +9109,7 @@ SubClassOf(obo:OHD_0010204 obo:OHD_0010203)
 
 # Class: obo:OHD_0010205 (recurrent juvenile parotitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010205 "Parotitis occuring in children ages 2-10 years old and occuring about eight times a year.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010205 "Parotitis occuring in children ages 2-10 years old and occuring about eight times a year."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010205 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010205 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010205 "2025-06-30T18:07:42Z"^^xsd:dateTime)
@@ -9118,7 +9118,7 @@ SubClassOf(obo:OHD_0010205 obo:OHD_0010204)
 
 # Class: obo:OHD_0010206 (salivary gland pain due to recurrent juvenile parotitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010206 "Salivary gland pain due to recurrent juvenile parotitis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010206 "Salivary gland pain due to recurrent juvenile parotitis."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010206 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010206 "1.2.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010206 <https://orcid.org/0009-0003-5583-4731>)
@@ -9130,7 +9130,7 @@ SubClassOf(obo:OHD_0010206 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010205))
 
 # Class: obo:OHD_0010207 (jaw bone pain due to malignant lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010207 "Jaw bone pain that results from a primary or seconday malignant lesion.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010207 "Jaw bone pain that results from a primary or seconday malignant lesion."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010207 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010207 "1.2.3.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010207 <https://orcid.org/0009-0002-7282-0836>)
@@ -9143,7 +9143,7 @@ SubClassOf(obo:OHD_0010207 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010184))
 
 # Class: obo:OHD_0010208 (local benign lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010208 "A disorder characterized by a non-cancerous growth.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010208 "A disorder characterized by a non-cancerous growth."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010208 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010208 "2025-06-30T18:19:03Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010208 "local benign lesion"@en)
@@ -9151,7 +9151,7 @@ SubClassOf(obo:OHD_0010208 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010209 (jaw bone pain due to local benign lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010209 "Jaw bone pain that results from a local benign lesion.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010209 "Jaw bone pain that results from a local benign lesion."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010209 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010209 "1.2.3.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010209 <https://orcid.org/0009-0002-7282-0836>)
@@ -9164,7 +9164,7 @@ SubClassOf(obo:OHD_0010209 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010208))
 
 # Class: obo:OHD_0010210 (local malignancy)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010210 "A malignant lesion that is confined to where the malignant cells began.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010210 "A malignant lesion that is confined to where the malignant cells began."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010210 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010210 "2025-06-30T18:25:59Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010210 "local malignancy"@en)
@@ -9172,7 +9172,7 @@ SubClassOf(obo:OHD_0010210 obo:OHD_0010184)
 
 # Class: obo:OHD_0010211 (jaw bone pain due to local malignancy)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010211 "Jaw bone pain due to a primary malignant lesion.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010211 "Jaw bone pain due to a primary malignant lesion."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010211 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010211 "1.2.3.4.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010211 <https://orcid.org/0009-0003-5583-4731>)
@@ -9184,7 +9184,7 @@ SubClassOf(obo:OHD_0010211 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010210))
 
 # Class: obo:OHD_0010212 (remote malignancy)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010212 "A malignant lesion that has spread from where teh malignant cells first began.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010212 "A malignant lesion that has spread from where teh malignant cells first began."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010212 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010212 "2025-06-30T18:28:29Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010212 "remote malignancy"@en)
@@ -9192,7 +9192,7 @@ SubClassOf(obo:OHD_0010212 obo:OHD_0010184)
 
 # Class: obo:OHD_0010213 (jaw bone pain due to remote malignancy)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010213 "Jaw bone pain due to a remote malignant lesion.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010213 "Jaw bone pain due to a remote malignant lesion."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010213 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010213 "1.2.3.4.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010213 <https://orcid.org/0009-0003-5583-4731>)
@@ -9204,7 +9204,7 @@ SubClassOf(obo:OHD_0010213 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010212))
 
 # Class: obo:OHD_0010214 (jaw bone pain due to therapy)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010214 "Jaw bone pain due to a theraputic intervention that has resulted in a lesion.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010214 "Jaw bone pain due to a theraputic intervention that has resulted in a lesion."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010214 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010214 "1.2.3.5")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010214 <https://orcid.org/0009-0003-5583-4731>)
@@ -9215,7 +9215,7 @@ SubClassOf(obo:OHD_0010214 obo:OHD_0010007)
 
 # Class: obo:OHD_0010215 (primary myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010215 "Pain in masticatory muscles, with or without functional impairment, not attributable to another disorder.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010215 "Pain in masticatory muscles, with or without functional impairment, not attributable to another disorder."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010215 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010215 "2.1"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010215 <https://orcid.org/0009-0003-5583-4731>)
@@ -9226,7 +9226,7 @@ SubClassOf(obo:OHD_0010215 obo:OHD_0010003)
 
 # Class: obo:OHD_0010216 (acute primary myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010216 "Mild to moderate levels of deep aching or pressing pain in the masticatory muscles, occurring episodically or unremittingly, often associated with functional impairment such as perceived difficulties in moving the lower jaw, chewing and/or yawning, etc., and with onset within the last 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010216 "Mild to moderate levels of deep aching or pressing pain in the masticatory muscles, occurring episodically or unremittingly, often associated with functional impairment such as perceived difficulties in moving the lower jaw, chewing and/or yawning, etc., and with onset within the last 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010216 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010216 "2.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010216 <https://orcid.org/0009-0003-5583-4731>)
@@ -9238,7 +9238,7 @@ SubClassOf(obo:OHD_0010216 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010140))
 
 # Class: obo:OHD_0010217 (chronic primary myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010217 "Mild to moderate levels of deep aching or pressing pain in the masticatory muscles, occurring episodically or unremittingly, often associated with functional impairment such as perceived difficulties in moving the lower jaw, chewing and/or yawning, etc., and with onset more than 3 months ago. It is often associated with psychosocial distress.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010217 "Mild to moderate levels of deep aching or pressing pain in the masticatory muscles, occurring episodically or unremittingly, often associated with functional impairment such as perceived difficulties in moving the lower jaw, chewing and/or yawning, etc., and with onset more than 3 months ago. It is often associated with psychosocial distress."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010217 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010217 "2.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010217 <https://orcid.org/0009-0003-5583-4731>)
@@ -9249,7 +9249,7 @@ SubClassOf(obo:OHD_0010217 obo:OHD_0010215)
 
 # Class: obo:OHD_0010218 (chronic infrequent primary myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010218 "Chronic primary myofascial orofacial pain occurring on less than one day a month.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010218 "Chronic primary myofascial orofacial pain occurring on less than one day a month."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010218 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010218 "2.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010218 <https://orcid.org/0009-0003-5583-4731>)
@@ -9261,7 +9261,7 @@ SubClassOf(obo:OHD_0010218 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010221))
 
 # Class: obo:OHD_0010219 (chronic frequent primary myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010219 "Chronic primary myofascial pain occurring 1-14 days a month for more than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010219 "Chronic primary myofascial pain occurring 1-14 days a month for more than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010219 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010219 "2.1.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010219 <https://orcid.org/0009-0003-5583-4731>)
@@ -9273,7 +9273,7 @@ SubClassOf(obo:OHD_0010219 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010220))
 
 # Class: obo:OHD_0010220 (chronic frequent pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010220 "Chronic pain that occurs 1-14 days a month.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010220 "Chronic pain that occurs 1-14 days a month."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010220 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010220 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010220 "2025-07-01T17:11:00Z"^^xsd:dateTime)
@@ -9282,7 +9282,7 @@ SubClassOf(obo:OHD_0010220 obo:OHD_0010141)
 
 # Class: obo:OHD_0010221 (chronic infrequent pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010221 "Chronic pain that occurs less than one day a month.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010221 "Chronic pain that occurs less than one day a month."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010221 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010221 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010221 "2025-07-01T17:13:04Z"^^xsd:dateTime)
@@ -9291,7 +9291,7 @@ SubClassOf(obo:OHD_0010221 obo:OHD_0010141)
 
 # Class: obo:OHD_0010222 (chronic frequent pain with pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010222 "Chronic frequent pain that occurs beyond the affected site.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010222 "Chronic frequent pain that occurs beyond the affected site."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010222 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010222 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010222 "2025-07-01T17:14:42Z"^^xsd:dateTime)
@@ -9300,7 +9300,7 @@ SubClassOf(obo:OHD_0010222 obo:OHD_0010220)
 
 # Class: obo:OHD_0010223 (chronic frequent pain without pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010223 "Chronic frequent pain that s localized to the affected area.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010223 "Chronic frequent pain that s localized to the affected area."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010223 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010223 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010223 "2025-07-01T17:15:41Z"^^xsd:dateTime)
@@ -9309,7 +9309,7 @@ SubClassOf(obo:OHD_0010223 obo:OHD_0010220)
 
 # Class: obo:OHD_0010224 (chronic frequent primary myofascial orofacial pain without pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010224 "Chronic frequent primary myofascial pain with no report of pain at a site beyond the boundary of the muscle (temporalis or masseter) being palpated.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010224 "Chronic frequent primary myofascial pain with no report of pain at a site beyond the boundary of the muscle (temporalis or masseter) being palpated."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010224 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010224 "2.1.2.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010224 <https://orcid.org/0009-0003-5583-4731>)
@@ -9321,7 +9321,7 @@ SubClassOf(obo:OHD_0010224 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010223))
 
 # Class: obo:OHD_0010225 (chronic frequent primary myofascial orofacial pain with pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010225 "Chronic frequent primary myofascial pain with a report of pain at a site beyond the boudary of the muscle being palpated.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010225 "Chronic frequent primary myofascial pain with a report of pain at a site beyond the boudary of the muscle being palpated."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010225 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010225 "2.1.2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010225 <https://orcid.org/0009-0003-5583-4731>)
@@ -9333,7 +9333,7 @@ SubClassOf(obo:OHD_0010225 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010222))
 
 # Class: obo:OHD_0010226 (chronic highly frequent pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010226 "Chronic pain that occurs more than 15 days a month for more than 4 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010226 "Chronic pain that occurs more than 15 days a month for more than 4 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010226 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010226 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010226 "2025-07-01T17:22:21Z"^^xsd:dateTime)
@@ -9342,7 +9342,7 @@ SubClassOf(obo:OHD_0010226 obo:OHD_0010220)
 
 # Class: obo:OHD_0010227 (chronic highly frequent primary myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010227 "Chronic primary myofascial pain occuring more than 15 days a month for an average of more than 4 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010227 "Chronic primary myofascial pain occuring more than 15 days a month for an average of more than 4 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010227 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010227 "2.1.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010227 <https://orcid.org/0009-0003-5583-4731>)
@@ -9354,7 +9354,7 @@ SubClassOf(obo:OHD_0010227 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010226))
 
 # Class: obo:OHD_0010228 (chronic highly frequent primary myofascial orofacial pain without pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010228 "Chronic highly frequent primary myofascial orofacial pain with no report of pain at a site beyond the boundary of the muscle (temporalis or masseter) being palpated.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010228 "Chronic highly frequent primary myofascial orofacial pain with no report of pain at a site beyond the boundary of the muscle (temporalis or masseter) being palpated."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010228 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010228 "2.1.2.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010228 <https://orcid.org/0009-0003-5583-4731>)
@@ -9366,7 +9366,7 @@ SubClassOf(obo:OHD_0010228 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010229))
 
 # Class: obo:OHD_0010229 (chronic highly frequent pain without pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010229 "Chronic highly frequent pain that is localized to the affected area.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010229 "Chronic highly frequent pain that is localized to the affected area."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010229 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010229 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010229 "2025-07-01T17:35:37Z"^^xsd:dateTime)
@@ -9375,7 +9375,7 @@ SubClassOf(obo:OHD_0010229 obo:OHD_0010226)
 
 # Class: obo:OHD_0010230 (chronic highly frequent pain with pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010230 "Chronic highly frequent pain with pain referral that occurs beyond the affected area.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010230 "Chronic highly frequent pain with pain referral that occurs beyond the affected area."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010230 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010230 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010230 "2025-07-01T17:37:56Z"^^xsd:dateTime)
@@ -9384,7 +9384,7 @@ SubClassOf(obo:OHD_0010230 obo:OHD_0010226)
 
 # Class: obo:OHD_0010231 (chronic highly frequent primary myofascial orofacial pain with pain referral)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010231 "Chronic highly frequent primary myofascial orofascial pain with a report of pain at a site beyond the boundary of the muscle being palpated.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010231 "Chronic highly frequent primary myofascial orofascial pain with a report of pain at a site beyond the boundary of the muscle being palpated."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010231 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010231 "2.1.2.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010231 <https://orcid.org/0009-0003-5583-4731>)
@@ -9396,7 +9396,7 @@ SubClassOf(obo:OHD_0010231 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010230))
 
 # Class: obo:OHD_0010232 (secondary myofascial orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010232 "Myofascial pain caused by an underlying disorder (inflammation, infection or muscle spasm).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010232 "Myofascial pain caused by an underlying disorder (inflammation, infection or muscle spasm)."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010232 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010232 "2.2"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010232 <https://orcid.org/0009-0003-5583-4731>)
@@ -9407,7 +9407,7 @@ SubClassOf(obo:OHD_0010232 obo:OHD_0010003)
 
 # Class: obo:OHD_0010233 (myofascial orofacial pain attributed to tendonitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010233 "Pain of tendon origin, affected by jaw movement, function or parafunction and replicated by provocation-testing of the relevant masticatory tendon. Limitation of mandibular movement(s) secondary to pain may be present. The temporalis tendon is a common site of tendonitis and may refer pain to the teeth and other nearby structures. Tendonitis can also occur in other masticatory muscle tendons.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010233 "Pain of tendon origin, affected by jaw movement, function or parafunction and replicated by provocation-testing of the relevant masticatory tendon. Limitation of mandibular movement(s) secondary to pain may be present. The temporalis tendon is a common site of tendonitis and may refer pain to the teeth and other nearby structures. Tendonitis can also occur in other masticatory muscle tendons."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010233 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010233 "2.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010233 <https://orcid.org/0009-0003-5583-4731>)
@@ -9419,7 +9419,7 @@ SubClassOf(obo:OHD_0010233 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010291))
 
 # Class: obo:OHD_0010234 (myofascial orofacial pain attributed to myositis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010234 "Pain caused by myositis affecting one or more masticatory muscles, with clinical characteristics of inﬂammation or infection: oedema, erythema and/or increased temperature. It generally arises acutely following direct trauma of the muscle or from infection, or chronically with autoimmune disease. Limitation of unassisted mandibular movements secondary to pain is often present. Calciﬁcation of the muscle can occur (i.e. myositis ossiﬁcans).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010234 "Pain caused by myositis affecting one or more masticatory muscles, with clinical characteristics of inﬂammation or infection: oedema, erythema and/or increased temperature. It generally arises acutely following direct trauma of the muscle or from infection, or chronically with autoimmune disease. Limitation of unassisted mandibular movements secondary to pain is often present. Calciﬁcation of the muscle can occur (i.e. myositis ossiﬁcans)."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010234 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010234 "2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010234 <https://orcid.org/0009-0003-5583-4731>)
@@ -9431,7 +9431,7 @@ SubClassOf(obo:OHD_0010234 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010305))
 
 # Class: obo:OHD_0010235 (myofascial orofacial pain attributed to muscle spasm)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010235 "Pain caused by sudden, involuntary, reversible tonic contraction of a muscle. Such spasm may affect any of the masticatory muscles. Acute malocclusion may be present.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010235 "Pain caused by sudden, involuntary, reversible tonic contraction of a muscle. Such spasm may affect any of the masticatory muscles. Acute malocclusion may be present."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010235 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010235 "2.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010235 <https://orcid.org/0009-0003-5583-4731>)
@@ -9442,7 +9442,7 @@ SubClassOf(obo:OHD_0010235 obo:OHD_0010232)
 
 # Class: obo:OHD_0010236 (temporomandibular joint pain attributed to arthritis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010236 "TMJ pain caused by persistent inflammation of articular tissues (due, for example, to trauma, infection, crystal deposition or autoimmune disorder). TMJ pain is common in TMJ arthritis, but TMJ arthritis can be present without pain.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010236 "TMJ pain caused by persistent inflammation of articular tissues (due, for example, to trauma, infection, crystal deposition or autoimmune disorder). TMJ pain is common in TMJ arthritis, but TMJ arthritis can be present without pain."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010236 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010236 "3.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010236 <https://orcid.org/0009-0003-5583-4731>)
@@ -9454,7 +9454,7 @@ SubClassOf(obo:OHD_0010236 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010306))
 
 # Class: obo:OHD_0010237 (temporomandibular joint pain attributed to non-systemic arthritis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010237 "Temporomandibular joint pain due to arthritis with evidence of systemic inflammatory joint disease but not evidence that associates it with the TMJ pain or no evidence of rheumatological disease.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010237 "Temporomandibular joint pain due to arthritis with evidence of systemic inflammatory joint disease but not evidence that associates it with the TMJ pain or no evidence of rheumatological disease."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010237 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010237 "3.2.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010237 <https://orcid.org/0009-0003-5583-4731>)
@@ -9466,7 +9466,7 @@ SubClassOf(obo:OHD_0010237 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010307))
 
 # Class: obo:OHD_0010238 (temporomandibular joint pain attributed to systemic arthritis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010238 "Temporomandibular joint due to arthritis with evidence of systemic inflammatory joint disease, pain developed in close temporal relation to other symptoms, and either the pain has significantly worsened in parallel with worsening of the systemic inflammatory joint disease or the pain has significantly improved or resolved with treatment of the systemic inflammatory joint disease.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010238 "Temporomandibular joint due to arthritis with evidence of systemic inflammatory joint disease, pain developed in close temporal relation to other symptoms, and either the pain has significantly worsened in parallel with worsening of the systemic inflammatory joint disease or the pain has significantly improved or resolved with treatment of the systemic inflammatory joint disease."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010238 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010238 "3.2.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010238 <https://orcid.org/0009-0003-5583-4731>)
@@ -9478,7 +9478,7 @@ SubClassOf(obo:OHD_0010238 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010308))
 
 # Class: obo:OHD_0010239 (temporomandibular joint pain attributed to disc displacement)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010239 "TMJ pain caused by TMJ disc displacement in the absence of TMJ arthritis. TMJ pain can here be due to mechanical derangements within the joint.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010239 "TMJ pain caused by TMJ disc displacement in the absence of TMJ arthritis. TMJ pain can here be due to mechanical derangements within the joint."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010239 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010239 "3.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010239 <https://orcid.org/0009-0003-5583-4731>)
@@ -9489,7 +9489,7 @@ SubClassOf(obo:OHD_0010239 obo:OHD_0010128)
 
 # Class: obo:OHD_0010240 (temporomandibular joint pain attributed to disc displacement with reduction)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010240 "Secondary temporomandibular joint pain due to TMJ disc displacement with reduction that any TMJ noise on jaw movement or function have been reported and clicking, popping, or snapping noises detected with palpation on the jaw opening and closing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010240 "Secondary temporomandibular joint pain due to TMJ disc displacement with reduction that any TMJ noise on jaw movement or function have been reported and clicking, popping, or snapping noises detected with palpation on the jaw opening and closing."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010240 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010240 "3.2.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010240 <https://orcid.org/0009-0003-5583-4731>)
@@ -9500,7 +9500,7 @@ SubClassOf(obo:OHD_0010240 obo:OHD_0010239)
 
 # Class: obo:OHD_0010241 (temporomandibular joint pain attributed to disc displacement with reduction, with intermittent locking)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010241 "Temporomandibular joint pain due to disc displacement with reduction with intermittent jaw locking with limited mouth opening.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010241 "Temporomandibular joint pain due to disc displacement with reduction with intermittent jaw locking with limited mouth opening."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010241 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010241 "3.2.2.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010241 <https://orcid.org/0009-0003-5583-4731>)
@@ -9511,7 +9511,7 @@ SubClassOf(obo:OHD_0010241 obo:OHD_0010240)
 
 # Class: obo:OHD_0010242 (temporomandibular joint pain attributed to disc displacement without reduction)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010242 "Secondary temporomandibulare join pain due to TMJ disc displacement without reduction, which has been diagnosed by jaw locking or limitation of jaw opening. Along with evidence of pain developing in close temporal relation to the disc dsiplacement, a significant worsening in pain paralelle.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010242 "Secondary temporomandibulare join pain due to TMJ disc displacement without reduction, which has been diagnosed by jaw locking or limitation of jaw opening. Along with evidence of pain developing in close temporal relation to the disc dsiplacement, a significant worsening in pain paralelle."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010242 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010242 "3.2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010242 <https://orcid.org/0009-0003-5583-4731>)
@@ -9522,7 +9522,7 @@ SubClassOf(obo:OHD_0010242 obo:OHD_0010239)
 
 # Class: obo:OHD_0010243 (temporomandibular joint pain due to degenerative joint disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010243 "TMJ pain caused by degenerative joint disorder (osteoarthrosis, osteoarthritis) in the absence of TMJ arthritis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010243 "TMJ pain caused by degenerative joint disorder (osteoarthrosis, osteoarthritis) in the absence of TMJ arthritis."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010243 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010243 "3.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010243 <https://orcid.org/0009-0003-5583-4731>)
@@ -9534,7 +9534,7 @@ SubClassOf(obo:OHD_0010243 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010309))
 
 # Class: obo:OHD_0010244 (temporomandibular joint pain due to subluxation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010244 "TMJ pain caused by subluxation, in the absence of TMJ arthritis. It is usually acute, and probably due to overstretching of tissues.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010244 "TMJ pain caused by subluxation, in the absence of TMJ arthritis. It is usually acute, and probably due to overstretching of tissues."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010244 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010244 "3.2.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010244 <https://orcid.org/0009-0003-5583-4731>)
@@ -9545,7 +9545,7 @@ SubClassOf(obo:OHD_0010244 obo:OHD_0010128)
 
 # Class: obo:OHD_0010245 (idiopathic trigeminal neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010245 "Trigeminal neuralgia with neither electrophysiological tests nor MRI showing significant abnormalities.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010245 "Trigeminal neuralgia with neither electrophysiological tests nor MRI showing significant abnormalities."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010245 "PMID:32103673")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010245 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010245 "2025-07-01T18:12:38Z"^^xsd:dateTime)
@@ -9557,7 +9557,7 @@ SubClassOf(obo:OHD_0010245 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010251))
 
 # Class: obo:OHD_0010246 (trigeminal neuralgia due to multiple sclerosis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010246 "Trigeminal neuralgia caused by a multiple sclerosis (MS) plaque or plaques in the pons or trigeminal root entry zone, and associated with other symptoms and/or clinical or laboratory findings of MS.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010246 "Trigeminal neuralgia caused by a multiple sclerosis (MS) plaque or plaques in the pons or trigeminal root entry zone, and associated with other symptoms and/or clinical or laboratory findings of MS."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010246 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010246 "4.1.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010246 <https://orcid.org/0009-0003-5583-4731>)
@@ -9568,7 +9568,7 @@ SubClassOf(obo:OHD_0010246 obo:OHD_0010131)
 
 # Class: obo:OHD_0010247 (trigeminal neuralgia due to space-occupying lesion)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010247 "Trigeminal neuralgia caused by contact between the affected trigeminal nerve and a space-occupying lesion.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010247 "Trigeminal neuralgia caused by contact between the affected trigeminal nerve and a space-occupying lesion."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010247 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010247 "4.1.1.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010247 <https://orcid.org/0009-0003-5583-4731>)
@@ -9579,7 +9579,7 @@ SubClassOf(obo:OHD_0010247 obo:OHD_0010131)
 
 # Class: obo:OHD_0010248 (concomitant continuous pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010248 "Pain that is persistently occuring in the background.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010248 "Pain that is persistently occuring in the background."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010248 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010248 "2025-07-02T19:13:19Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010248 "concomitant continuous pain"@en)
@@ -9587,7 +9587,7 @@ SubClassOf(obo:OHD_0010248 obo:OGMS_0000085)
 
 # Class: obo:OHD_0010249 (classical trigeminal neuralgia with concomitant continuous pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010249 "Classical trigeminal neuralgia with persistent background pain.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010249 "Classical trigeminal neuralgia with persistent background pain."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010249 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010249 "4.1.1.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010249 <https://orcid.org/0009-0003-5583-4731>)
@@ -9599,7 +9599,7 @@ SubClassOf(obo:OHD_0010249 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010248))
 
 # Class: obo:OHD_0010250 (idiopathic trigeminal neuralgia with concomitant continuous pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010250 "Idiopathic trigeminal neuralgia with recurrent paroxysms of unilateral facial pain that is concomitant continuous of near-continuous pain between attacks in the affected trigeminal distirbution.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010250 "Idiopathic trigeminal neuralgia with recurrent paroxysms of unilateral facial pain that is concomitant continuous of near-continuous pain between attacks in the affected trigeminal distirbution."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010250 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010250 "4.1.1.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010250 <https://orcid.org/0009-0003-5583-4731>)
@@ -9611,7 +9611,7 @@ SubClassOf(obo:OHD_0010250 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010248))
 
 # Class: obo:OHD_0010251 (idiopathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010251 "Pain with no identifiable cause.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010251 "Pain with no identifiable cause."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010251 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010251 "2025-07-02T19:20:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010251 "idiopathic pain"@en)
@@ -9619,7 +9619,7 @@ SubClassOf(obo:OHD_0010251 obo:OGMS_0000085)
 
 # Class: obo:OHD_0010252 (neuropathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010252 "Pain cause by damage to nerve fibers.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010252 "Pain cause by damage to nerve fibers."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010252 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010252 "2025-07-02T19:21:25Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010252 "neuropathic pain"@en)
@@ -9627,7 +9627,7 @@ SubClassOf(obo:OHD_0010252 obo:OGMS_0000085)
 
 # Class: obo:OHD_0010253 (glossopharyngeal neuropathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010253 "Glossopharyngeal nerve associated pain that occurs within the distribution of the glossopharyngeal nerve (posterior part of the tongue, tonsillar fossa, pharynx or beneath the angle of the lower jaw). In addition, pain is commonly perceived in the ipsilateral ear. The primary pain is usually continuous or near-continuous, and commonly described as burning or squeezing, or likened to pins and needles. Brief paroxysms may be superimposed but they are not the predominant pain type. This combination distinguishes 4.2.2 Glossopharyngeal neuropathic pain from 4.2.1 Glossopharyngeal neuralgia. Sensory deficits may be present in the ipsilateral posterior part of the tongue and tonsillar fossa, and the gag reflex may be weak or missing.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010253 "Glossopharyngeal nerve associated pain that occurs within the distribution of the glossopharyngeal nerve (posterior part of the tongue, tonsillar fossa, pharynx or beneath the angle of the lower jaw). In addition, pain is commonly perceived in the ipsilateral ear. The primary pain is usually continuous or near-continuous, and commonly described as burning or squeezing, or likened to pins and needles. Brief paroxysms may be superimposed but they are not the predominant pain type. This combination distinguishes 4.2.2 Glossopharyngeal neuropathic pain from 4.2.1 Glossopharyngeal neuralgia. Sensory deficits may be present in the ipsilateral posterior part of the tongue and tonsillar fossa, and the gag reflex may be weak or missing."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010253 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010253 "4.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010253 <https://orcid.org/0009-0003-5583-4731>)
@@ -9640,7 +9640,7 @@ SubClassOf(obo:OHD_0010253 obo:OHD_0010132)
 
 # Class: obo:OHD_0010254 (idiopathic glossopharyngeal neuropathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010254 "Unilateral continuous or near-continuous pain, with or without superimposed brief paroxysms, in the distribution(s) of the glossopharyngeal nerve and of unknown aetiology.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010254 "Unilateral continuous or near-continuous pain, with or without superimposed brief paroxysms, in the distribution(s) of the glossopharyngeal nerve and of unknown aetiology."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010254 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010254 "4.2.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010254 <https://orcid.org/0009-0003-5583-4731>)
@@ -9652,7 +9652,7 @@ SubClassOf(obo:OHD_0010254 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010251))
 
 # Class: obo:OHD_0010255 (orofacial pain with headache presentation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010255 "Orofacial pains resembling presentations of primary headaches.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010255 "Orofacial pains resembling presentations of primary headaches."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010255 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010255 "5"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010255 <https://orcid.org/0009-0003-5583-4731>)
@@ -9663,7 +9663,7 @@ SubClassOf(obo:OHD_0010255 obo:OHD_0010000)
 
 # Class: obo:OHD_0010256 (orofacial migraine)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010256 "Episodic or chronic pain exclusively in the orofacial region, without head pain, with the characteristics and associated features of 1. Migraine described in ICHD-3.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010256 "Episodic or chronic pain exclusively in the orofacial region, without head pain, with the characteristics and associated features of 1. Migraine described in ICHD-3."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010256 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010256 "5.1"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010256 <https://orcid.org/0009-0003-5583-4731>)
@@ -9674,7 +9674,7 @@ SubClassOf(obo:OHD_0010256 obo:OHD_0010255)
 
 # Class: obo:OHD_0010257 (episodic orofacial migraine)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010257 "Recurrent orofacial pain (OFP) attacks, without head pain, lasting 4–72 hours. Typical characteristics of the pain are unilateral location, pulsating quality, moderate or severe intensity, aggravation by routine physical activity and association with nausea and/or photophobia and phonophobia.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010257 "Recurrent orofacial pain (OFP) attacks, without head pain, lasting 4–72 hours. Typical characteristics of the pain are unilateral location, pulsating quality, moderate or severe intensity, aggravation by routine physical activity and association with nausea and/or photophobia and phonophobia."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010257 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010257 "5.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010257 <https://orcid.org/0009-0003-5583-4731>)
@@ -9685,7 +9685,7 @@ SubClassOf(obo:OHD_0010257 obo:OHD_0010256)
 
 # Class: obo:OHD_0010258 (chronic orofacial migraine)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010258 "Facial or oral pain occurring on 15 or more days per month for more than 3 months, which has the features of migraine on at least 8 days per month.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010258 "Facial or oral pain occurring on 15 or more days per month for more than 3 months, which has the features of migraine on at least 8 days per month."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010258 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010258 "5.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010258 <https://orcid.org/0009-0003-5583-4731>)
@@ -9696,7 +9696,7 @@ SubClassOf(obo:OHD_0010258 obo:OHD_0010256)
 
 # Class: obo:OHD_0010259 (tension-type orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010259 "Episodic or chronic pain exclusively in the orofacial region, without head pain, with the characteristics and associated features of 2. Tension-type headache described in the International Classification of Headache Disorders 3rd Edition, which can include pressing or tightening with mild to moderate intensity with bilateral location.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010259 "Episodic or chronic pain exclusively in the orofacial region, without head pain, with the characteristics and associated features of 2. Tension-type headache described in the International Classification of Headache Disorders 3rd Edition, which can include pressing or tightening with mild to moderate intensity with bilateral location."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010259 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010259 "5.2"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010259 <https://orcid.org/0009-0003-5583-4731>)
@@ -9707,7 +9707,7 @@ SubClassOf(obo:OHD_0010259 obo:OHD_0010255)
 
 # Class: obo:OHD_0010260 (trigeminal autonomic orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010260 "Attacks of pain, exclusively in the orofacial region, without head pain, with the characteristics and associated features of a disorder described under 3. Trigeminal autonomic cephalalgias in the International Classification of Headache Disorders 3rd Edition, which include conjunctival injection and/or lacrimation, nasal congestion and/or rhinorrhoea, eyelid oedema, forehead and facial sweating, miosis and/or ptosis.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010260 "Attacks of pain, exclusively in the orofacial region, without head pain, with the characteristics and associated features of a disorder described under 3. Trigeminal autonomic cephalalgias in the International Classification of Headache Disorders 3rd Edition, which include conjunctival injection and/or lacrimation, nasal congestion and/or rhinorrhoea, eyelid oedema, forehead and facial sweating, miosis and/or ptosis."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010260 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010260 "5.3"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010260 <https://orcid.org/0009-0003-5583-4731>)
@@ -9718,7 +9718,7 @@ SubClassOf(obo:OHD_0010260 obo:OHD_0010255)
 
 # Class: obo:OHD_0010261 (orofacial cluster attacks)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010261 "Attacks of severe, strictly unilateral facial and/or oral pain, without head pain, lasting 15–180 minutes and occurring from once every other day to eight times a day. The pain is associated with ipsilateral conjunctival injection, lacrimation, nasal congestion, rhinorrhoea, forehead and facial sweating, miosis, ptosis and/or eyelid oedema, and/or with restlessness or agitation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010261 "Attacks of severe, strictly unilateral facial and/or oral pain, without head pain, lasting 15–180 minutes and occurring from once every other day to eight times a day. The pain is associated with ipsilateral conjunctival injection, lacrimation, nasal congestion, rhinorrhoea, forehead and facial sweating, miosis, ptosis and/or eyelid oedema, and/or with restlessness or agitation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010261 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010261 "5.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010261 <https://orcid.org/0009-0003-5583-4731>)
@@ -9729,7 +9729,7 @@ SubClassOf(obo:OHD_0010261 obo:OHD_0010260)
 
 # Class: obo:OHD_0010262 (episodic orofacial cluster attacks)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010262 "Orofacial cluster attacks occurring in periods lasting from 7 days to 1 year, separated by pain-free periods lasting at least 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010262 "Orofacial cluster attacks occurring in periods lasting from 7 days to 1 year, separated by pain-free periods lasting at least 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010262 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010262 "5.3.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010262 <https://orcid.org/0009-0003-5583-4731>)
@@ -9740,7 +9740,7 @@ SubClassOf(obo:OHD_0010262 obo:OHD_0010261)
 
 # Class: obo:OHD_0010263 (chronic orofacial cluster attacks)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010263 "Orofacial cluster attacks occurring for more than 1 year without remission, or with remission periods lasting less than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010263 "Orofacial cluster attacks occurring for more than 1 year without remission, or with remission periods lasting less than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010263 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010263 "5.3.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010263 <https://orcid.org/0009-0003-5583-4731>)
@@ -9751,7 +9751,7 @@ SubClassOf(obo:OHD_0010263 obo:OHD_0010261)
 
 # Class: obo:OHD_0010264 (paroxysmal hemifacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010264 "Attacks of severe, strictly hemifacial pain, without head pain, lasting 2–30 minutes and occurring several or many times a day. The attacks may be associated with ipsilateral conjunctival injection, lacrimation, nasal congestion, rhinorrhoea, forehead and facial sweating, miosis, ptosis and/or eyelid oedema.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010264 "Attacks of severe, strictly hemifacial pain, without head pain, lasting 2–30 minutes and occurring several or many times a day. The attacks may be associated with ipsilateral conjunctival injection, lacrimation, nasal congestion, rhinorrhoea, forehead and facial sweating, miosis, ptosis and/or eyelid oedema."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010264 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010264 "5.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010264 <https://orcid.org/0009-0003-5583-4731>)
@@ -9762,7 +9762,7 @@ SubClassOf(obo:OHD_0010264 obo:OHD_0010260)
 
 # Class: obo:OHD_0010265 (episodic paroxysmal hemifacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010265 "Attacks of paroxysmal hemifacial pain occurring in periods lasting from 7 days to 1 year, separated by pain-free periods lasting at least 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010265 "Attacks of paroxysmal hemifacial pain occurring in periods lasting from 7 days to 1 year, separated by pain-free periods lasting at least 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010265 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010265 "5.3.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010265 <https://orcid.org/0009-0003-5583-4731>)
@@ -9774,7 +9774,7 @@ SubClassOf(obo:OHD_0010265 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010266))
 
 # Class: obo:OHD_0010266 (episodic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010266 "Pain occuring from 7 days to 1 year, separated by pain-free periods lasting at least 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010266 "Pain occuring from 7 days to 1 year, separated by pain-free periods lasting at least 3 months."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010266 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010266 "2025-07-07T17:20:14Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010266 "episodic pain"@en)
@@ -9782,7 +9782,7 @@ SubClassOf(obo:OHD_0010266 obo:OGMS_0000085)
 
 # Class: obo:OHD_0010267 (chronic paroxysmal hemifacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010267 "Attacks of paroxysmal hemifacial pain occurring for more than 1 year without remission, or with remission periods lasting less than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010267 "Attacks of paroxysmal hemifacial pain occurring for more than 1 year without remission, or with remission periods lasting less than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010267 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010267 "5.3.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010267 <https://orcid.org/0009-0003-5583-4731>)
@@ -9793,7 +9793,7 @@ SubClassOf(obo:OHD_0010267 obo:OHD_0010264)
 
 # Class: obo:OHD_0010268 (short-lasting unilateral neuralgiform facial pain attacks with cranial autonomic symptoms (SUNFA))
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010268 "Attacks of moderate or severe, strictly unilateral oral and/or facial pain, without head pain, lasting seconds to minutes, occurring at least once a day and usually associated with prominent lacrimation and redness of the ipsilateral eye and/or other local autonomic symptoms and/or signs.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010268 "Attacks of moderate or severe, strictly unilateral oral and/or facial pain, without head pain, lasting seconds to minutes, occurring at least once a day and usually associated with prominent lacrimation and redness of the ipsilateral eye and/or other local autonomic symptoms and/or signs."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010268 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010268 "5.3.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010268 <https://orcid.org/0009-0003-5583-4731>)
@@ -9804,7 +9804,7 @@ SubClassOf(obo:OHD_0010268 obo:OHD_0010260)
 
 # Class: obo:OHD_0010269 (episodic SUNFA)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010269 "Attacks of SUNFA occurring in periods lasting from 7 days to 1 year, separated by pain-free periods lasting at least 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010269 "Attacks of SUNFA occurring in periods lasting from 7 days to 1 year, separated by pain-free periods lasting at least 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010269 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010269 "5.3.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010269 <https://orcid.org/0009-0003-5583-4731>)
@@ -9815,7 +9815,7 @@ SubClassOf(obo:OHD_0010269 obo:OHD_0010268)
 
 # Class: obo:OHD_0010270 (chronic SUNFA)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010270 "Attacks of SUNFA occurring for more than 1 year without remission, or with remission periods lasting less than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010270 "Attacks of SUNFA occurring for more than 1 year without remission, or with remission periods lasting less than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010270 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010270 "5.3.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010270 <https://orcid.org/0009-0003-5583-4731>)
@@ -9826,7 +9826,7 @@ SubClassOf(obo:OHD_0010270 obo:OHD_0010268)
 
 # Class: obo:OHD_0010271 (hemifacial continuous pain with autonomic symptoms)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010271 "While no isolated facial equivalent of 3.4 Hemicrania continua, described in International Classification of Headache Disorders 3rd Edition,, has so far been clearly established, extension of pain into the face in hemicrania continua has been described. Thus, pain referral and/or radiation to oral and/or facial structures may cause diagnostic difficulties.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010271 "While no isolated facial equivalent of 3.4 Hemicrania continua, described in International Classification of Headache Disorders 3rd Edition,, has so far been clearly established, extension of pain into the face in hemicrania continua has been described. Thus, pain referral and/or radiation to oral and/or facial structures may cause diagnostic difficulties."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010271 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010271 "5.3.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010271 <https://orcid.org/0009-0003-5583-4731>)
@@ -9837,7 +9837,7 @@ SubClassOf(obo:OHD_0010271 obo:OHD_0010260)
 
 # Class: obo:OHD_0010272 (neurovascular orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010272 "Attacks of variable duration of moderate or severe intraoral pain, without head pain, often accompanied by toothache-like symptoms, with mild autonomic and/or migrainous symptoms. Two subforms are represented by patients with relatively short attacks (1–4 hours) and those with longer attacks (>4 hours).")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010272 "Attacks of variable duration of moderate or severe intraoral pain, without head pain, often accompanied by toothache-like symptoms, with mild autonomic and/or migrainous symptoms. Two subforms are represented by patients with relatively short attacks (1–4 hours) and those with longer attacks (>4 hours)."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010272 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010272 "5.4"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010272 <https://orcid.org/0009-0003-5583-4731>)
@@ -9848,7 +9848,7 @@ SubClassOf(obo:OHD_0010272 obo:OHD_0010255)
 
 # Class: obo:OHD_0010273 (short-lasting neurovascular orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010273 "Neurovascular orofacial pain that lasts between 1-4 hours.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010273 "Neurovascular orofacial pain that lasts between 1-4 hours."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010273 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010273 "5.4.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010273 <https://orcid.org/0009-0003-5583-4731>)
@@ -9859,7 +9859,7 @@ SubClassOf(obo:OHD_0010273 obo:OHD_0010272)
 
 # Class: obo:OHD_0010274 (long-lasting neurovascular orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010274 "Neurovascular orofacial pain that lasts more than 4 hours.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010274 "Neurovascular orofacial pain that lasts more than 4 hours."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010274 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010274 "5.4.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010274 <https://orcid.org/0009-0003-5583-4731>)
@@ -9870,7 +9870,7 @@ SubClassOf(obo:OHD_0010274 obo:OHD_0010272)
 
 # Class: obo:OHD_0010275 (idiopathic orofacial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010275 "Orofacial pain involving unilateral or bilateral intraoral or facial pain in the distribution(s) of one or more branches of the trigeminal nerve(s) for which the aetiology is unknown. The pain is usually persistent, of moderate intensity, poorly localized and described as dull, pressing or of burning character.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010275 "Orofacial pain involving unilateral or bilateral intraoral or facial pain in the distribution(s) of one or more branches of the trigeminal nerve(s) for which the aetiology is unknown. The pain is usually persistent, of moderate intensity, poorly localized and described as dull, pressing or of burning character."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010275 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010275 "6"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010275 <https://orcid.org/0009-0003-5583-4731>)
@@ -9881,7 +9881,7 @@ SubClassOf(obo:OHD_0010275 obo:OHD_0010000)
 
 # Class: obo:OHD_0010276 (burning mouth syndrome (BMS))
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010276 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day for more than 3 months, without evident causative lesions on clinical examination and investigation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010276 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day for more than 3 months, without evident causative lesions on clinical examination and investigation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010276 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010276 "6.1"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010276 <https://orcid.org/0009-0003-5583-4731>)
@@ -9892,7 +9892,7 @@ SubClassOf(obo:OHD_0010276 obo:OHD_0010275)
 
 # Class: obo:OHD_0010277 (burning mouth syndrome without somatosensory changes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010277 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day for more than 3 months, unaccompanied by somatosensory changes and without evident causative lesions on clinical examination and investigation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010277 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day for more than 3 months, unaccompanied by somatosensory changes and without evident causative lesions on clinical examination and investigation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010277 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010277 "6.1.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010277 <https://orcid.org/0009-0003-5583-4731>)
@@ -9903,7 +9903,7 @@ SubClassOf(obo:OHD_0010277 obo:OHD_0010276)
 
 # Class: obo:OHD_0010278 (burning mouth syndrome with somatosensory changes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010278 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day for more than 3 months and accompanied by negative and/or positive somatosensory changes, without evident causative lesion(s) on clinical examination and investigation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010278 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day for more than 3 months and accompanied by negative and/or positive somatosensory changes, without evident causative lesion(s) on clinical examination and investigation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010278 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010278 "6.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010278 <https://orcid.org/0009-0003-5583-4731>)
@@ -9914,7 +9914,7 @@ SubClassOf(obo:OHD_0010278 obo:OHD_0010276)
 
 # Class: obo:OHD_0010279 (probable burning mouth syndrome)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010279 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day but for less than 3 months, without evident causative lesions on clinical examination and investigation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010279 "An intraoral burning or dysaesthetic sensation, recurring daily for more than 2 hours per day but for less than 3 months, without evident causative lesions on clinical examination and investigation."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010279 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010279 "6.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010279 <https://orcid.org/0009-0003-5583-4731>)
@@ -9925,7 +9925,7 @@ SubClassOf(obo:OHD_0010279 obo:OHD_0010276)
 
 # Class: obo:OHD_0010280 (persistent idiopathic facial pain (PIFP))
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010280 "Persistent facial pain, with variable features, recurring daily for more than 2 hours per day for more than 3 months, in the absence of clinical neurological deficit or preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010280 "Persistent facial pain, with variable features, recurring daily for more than 2 hours per day for more than 3 months, in the absence of clinical neurological deficit or preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010280 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010280 "6.2"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010280 <https://orcid.org/0009-0003-5583-4731>)
@@ -9936,7 +9936,7 @@ SubClassOf(obo:OHD_0010280 obo:OHD_0010275)
 
 # Class: obo:OHD_0010281 (persistent idiopathic facial pain without somatosensory changes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010281 "Persistent facial pain, with variable features, recurring daily for more than 2 hours per day for more than 3 months, unaccompanied by somatosensory changes and in the absence of clinical neurological deficit or preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010281 "Persistent facial pain, with variable features, recurring daily for more than 2 hours per day for more than 3 months, unaccompanied by somatosensory changes and in the absence of clinical neurological deficit or preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010281 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010281 "6.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010281 <https://orcid.org/0009-0003-5583-4731>)
@@ -9947,7 +9947,7 @@ SubClassOf(obo:OHD_0010281 obo:OHD_0010280)
 
 # Class: obo:OHD_0010282 (persistent idiopathic facial pain with somatosensory changes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010282 "Persistent facial pain, with variable features, recurring daily for more than 2 hours per day for more than 3 months and accompanied by negative and/or positive somatosensory changes, in the absence of clinical neurological deficit or preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010282 "Persistent facial pain, with variable features, recurring daily for more than 2 hours per day for more than 3 months and accompanied by negative and/or positive somatosensory changes, in the absence of clinical neurological deficit or preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010282 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010282 "6.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010282 <https://orcid.org/0009-0003-5583-4731>)
@@ -9958,7 +9958,7 @@ SubClassOf(obo:OHD_0010282 obo:OHD_0010280)
 
 # Class: obo:OHD_0010283 (probable persistent idiopathic facial pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010283 "Facial pain, with variable features, recurring daily for more than 2 hours per day but for less than 3 months, in the absence of clinical neurological deficit or preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010283 "Facial pain, with variable features, recurring daily for more than 2 hours per day but for less than 3 months, in the absence of clinical neurological deficit or preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010283 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010283 "6.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010283 <https://orcid.org/0009-0003-5583-4731>)
@@ -9969,7 +9969,7 @@ SubClassOf(obo:OHD_0010283 obo:OHD_0010280)
 
 # Class: obo:OHD_0010284 (persistent idiopathic dentoalveolar pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010284 "Persistent unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features but recurring daily for more than 2 hours per day for more than 3 months, in the absence of any preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010284 "Persistent unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features but recurring daily for more than 2 hours per day for more than 3 months, in the absence of any preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010284 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010284 "6.3"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010284 <https://orcid.org/0009-0003-5583-4731>)
@@ -9980,7 +9980,7 @@ SubClassOf(obo:OHD_0010284 obo:OHD_0010275)
 
 # Class: obo:OHD_0010285 (persistent idiopathic dentoalveolar pain without somatosensory changes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010285 "Persistent unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features, recurring daily for more than 2 hours per day for more than 3 months, unaccompanied by somatosensory changes and in the absence of any preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010285 "Persistent unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features, recurring daily for more than 2 hours per day for more than 3 months, unaccompanied by somatosensory changes and in the absence of any preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010285 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010285 "6.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010285 <https://orcid.org/0009-0003-5583-4731>)
@@ -9991,7 +9991,7 @@ SubClassOf(obo:OHD_0010285 obo:OHD_0010284)
 
 # Class: obo:OHD_0010286 (persistent idiopathic dentoalveolar pain with somatosensory changes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010286 "Persistent unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features, recurring daily for more than 2 hours per day for more than 3 months and accompanied by negative and/or positive somatosensory changes, in the absence of any preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010286 "Persistent unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features, recurring daily for more than 2 hours per day for more than 3 months and accompanied by negative and/or positive somatosensory changes, in the absence of any preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010286 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010286 "6.3.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010286 <https://orcid.org/0009-0003-5583-4731>)
@@ -10002,7 +10002,7 @@ SubClassOf(obo:OHD_0010286 obo:OHD_0010284)
 
 # Class: obo:OHD_0010287 (probable persistent idiopathic dentoalveolar pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010287 "Unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features, recurring daily for more than 2 hours per day but for less than 3 months, in the absence of any preceding causative event.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010287 "Unilateral intraoral dentoalveolar pain, rarely occurring in multiple sites, with variable features, recurring daily for more than 2 hours per day but for less than 3 months, in the absence of any preceding causative event."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010287 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010287 "6.3.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010287 <https://orcid.org/0009-0003-5583-4731>)
@@ -10013,7 +10013,7 @@ SubClassOf(obo:OHD_0010287 obo:OHD_0010284)
 
 # Class: obo:OHD_0010288 (constant unilateral facial pain with additional attacks (CUFPA))
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010288 "Constant (unremitting) dull unilateral facial pain of mild to moderate intensity, accompanied by distinct attacks of moderate to severe pain in the same location lasting 10--30 minutes. There are no typical autonomic and/or migrainoid features accompanying either the constant pain or the additional pain attacks.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010288 "Constant (unremitting) dull unilateral facial pain of mild to moderate intensity, accompanied by distinct attacks of moderate to severe pain in the same location lasting 10--30 minutes. There are no typical autonomic and/or migrainoid features accompanying either the constant pain or the additional pain attacks."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010288 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010288 "6.4"^^xsd:decimal)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010288 <https://orcid.org/0009-0003-5583-4731>)
@@ -10024,7 +10024,7 @@ SubClassOf(obo:OHD_0010288 obo:OHD_0010275)
 
 # Class: obo:OHD_0010289 (inflammation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010289 "A disorder in a tissue or organ that is marked by capillary dilatation, leukocytic infiltration, redness, heat, pain, swelling, and often loss of function, which is a response cellular injury or infection.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010289 "A disorder in a tissue or organ that is marked by capillary dilatation, leukocytic infiltration, redness, heat, pain, swelling, and often loss of function, which is a response cellular injury or infection."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010289 "ISBN:978-0-8153-4505-3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010289 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010289 <https://orcid.org/0009-0003-5583-4731>)
@@ -10035,7 +10035,7 @@ SubClassOf(obo:OHD_0010289 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010290 (periodontal disease course)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010290 "A disease course in which periodontal disease is realized.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010290 "A disease course in which periodontal disease is realized."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010290 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010290 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010290 <https://orcid.org/0009-0003-5583-4731>)
@@ -10045,7 +10045,7 @@ SubClassOf(obo:OHD_0010290 obo:OGMS_0000063)
 
 # Class: obo:OHD_0010291 (tendonitis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010291 "A disorder of a tendon caused by inflammation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010291 "A disorder of a tendon caused by inflammation."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010291 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010291 "2025-07-07T18:48:59Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010291 "tendonitis"@en)
@@ -10054,7 +10054,7 @@ SubClassOf(obo:OHD_0010291 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010292 (gingival pain due to autoimmunity)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010292 "Gingival pain due to gingivitis resulting from an autoimmune disease or disorder.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010292 "Gingival pain due to gingivitis resulting from an autoimmune disease or disorder."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010292 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010292 "1.1.3.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010292 <https://orcid.org/0009-0002-7282-0836>)
@@ -10067,7 +10067,7 @@ SubClassOf(obo:OHD_0010292 ObjectSomeValuesFrom(obo:RO_0002410 obo:OBI_1110054))
 
 # Class: obo:OHD_0010293 (gingival pain attributed to hypersensitivity or allergic reaction)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010293 "GIngival pain due to gingivitis resulting from a hypersensitivity or allergic reaction in the gingival tissues.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010293 "GIngival pain due to gingivitis resulting from a hypersensitivity or allergic reaction in the gingival tissues."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010293 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010293 "1.1.3.1.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010293 <https://orcid.org/0009-0003-5583-4731>)
@@ -10079,7 +10079,7 @@ SubClassOf(obo:OHD_0010293 ObjectSomeValuesFrom(obo:RO_0002410 obo:GO_0002524))
 
 # Class: obo:OHD_0010294 (oral mucosal pain due to autoimmunity)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010294 "Oral mucosal pain due to oralmucosal inflammation resulting from an autoimmue disease.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010294 "Oral mucosal pain due to oralmucosal inflammation resulting from an autoimmue disease."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010294 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010294 "1.2.1.1.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010294 <https://orcid.org/0009-0002-7282-0836>)
@@ -10092,7 +10092,7 @@ SubClassOf(obo:OHD_0010294 ObjectSomeValuesFrom(obo:RO_0002410 obo:OBI_1110054))
 
 # Class: obo:OHD_0010295 (oral mucosal pain due to hypersensitivity or allergic reaction)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010295 "Oral mucosal pain due to oral mucosal inflammation resulting from a hypersensitivity or allergic reaction in the oral mucosa.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010295 "Oral mucosal pain due to oral mucosal inflammation resulting from a hypersensitivity or allergic reaction in the oral mucosa."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010295 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010295 "1.2.1.1.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010295 <https://orcid.org/0009-0003-5583-4731>)
@@ -10104,7 +10104,7 @@ SubClassOf(obo:OHD_0010295 ObjectSomeValuesFrom(obo:RO_0002410 obo:GO_0002524))
 
 # Class: obo:OHD_0010297 (salivary gland pain due to immunologically mediated disorder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010297 "Salivary gland pain due to an immunologically mediated disorder.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010297 "Salivary gland pain due to an immunologically mediated disorder."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010297 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010297 "1.2.2.4")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010297 <https://orcid.org/0009-0003-5583-4731>)
@@ -10116,7 +10116,7 @@ SubClassOf(obo:OHD_0010297 ObjectSomeValuesFrom(obo:RO_0002410 obo:GO_0006955))
 
 # Class: obo:OHD_0010298 (salivary gland pain due to obstructive cause)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010298 "Salivary gland pain due to an obstruction of the salivary duct.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010298 "Salivary gland pain due to an obstruction of the salivary duct."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010298 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010298 "1.2.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010298 <https://orcid.org/0009-0003-5583-4731>)
@@ -10127,7 +10127,7 @@ SubClassOf(obo:OHD_0010298 obo:OHD_0010023)
 
 # Class: obo:OHD_0010299 (trigeminal neuropathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010299 "Orofacial pain in the distribution of one or more branches of the trigeminal nerve. The primary pain is usually continuous or near-continuous, and commonly described as burning, squeezing, aching or likened to pins and needles.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010299 "Orofacial pain in the distribution of one or more branches of the trigeminal nerve. The primary pain is usually continuous or near-continuous, and commonly described as burning, squeezing, aching or likened to pins and needles."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010299 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010299 "4.1.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010299 <https://orcid.org/0009-0002-7282-0836>)
@@ -10142,7 +10142,7 @@ SubClassOf(obo:OHD_0010299 obo:OHD_0010059)
 
 # Class: obo:OHD_0010300 (trigeminal neuropathic pain attributed to herpes zoster)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010300 "Unilateral facial pain of less than 3 months’ duration in the distribution of one or more branches of the trigeminal nerve, caused by, and associated with other symptoms and/or clinical signs of, acute herpes zoster.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010300 "Unilateral facial pain of less than 3 months’ duration in the distribution of one or more branches of the trigeminal nerve, caused by, and associated with other symptoms and/or clinical signs of, acute herpes zoster."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010300 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010300 "4.1.2.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010300 <https://orcid.org/0009-0003-5583-4731>)
@@ -10153,7 +10153,7 @@ SubClassOf(obo:OHD_0010300 obo:OHD_0010299)
 
 # Class: obo:OHD_0010301 (trigeminal postherpetic neuralgia)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010301 "Unilateral facial pain persisting or recurring for at least 3 months in the distribution(s) of one or more branches of the trigeminal nerve, with variable sensory changes, caused by herpes zoster.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010301 "Unilateral facial pain persisting or recurring for at least 3 months in the distribution(s) of one or more branches of the trigeminal nerve, with variable sensory changes, caused by herpes zoster."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010301 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010301 "4.1.2.2")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010301 <https://orcid.org/0009-0003-5583-4731>)
@@ -10164,7 +10164,7 @@ SubClassOf(obo:OHD_0010301 obo:OHD_0010299)
 
 # Class: obo:OHD_0010302 (post-traumatic trigeminal neuropathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010302 "Unilateral or bilateral facial or oral pain following and caused by trauma to the trigeminal nerve(s), with other symptoms and/or clinical signs of trigeminal nerve dysfunction, and persisting or recurring for more than 3 months.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010302 "Unilateral or bilateral facial or oral pain following and caused by trauma to the trigeminal nerve(s), with other symptoms and/or clinical signs of trigeminal nerve dysfunction, and persisting or recurring for more than 3 months."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010302 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010302 "4.1.2.3")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010302 <https://orcid.org/0009-0003-5583-4731>)
@@ -10175,7 +10175,7 @@ SubClassOf(obo:OHD_0010302 obo:OHD_0010299)
 
 # Class: obo:OHD_0010303 (probable post-traumatic trigeminal neuropathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010303 "Post-traumatic trigeminal neuropathic pain without a diagnostic test confirmation of a lesion of the peripheral trieminal nerve explaining the pain.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010303 "Post-traumatic trigeminal neuropathic pain without a diagnostic test confirmation of a lesion of the peripheral trieminal nerve explaining the pain."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010303 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010303 "4.1.2.3.1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010303 <https://orcid.org/0009-0003-5583-4731>)
@@ -10186,7 +10186,7 @@ SubClassOf(obo:OHD_0010303 obo:OHD_0010302)
 
 # Class: obo:OHD_0010304 (idiopathic trigeminal neuropathic pain)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010304 "Unilateral or bilateral facial pain in the distribution(s) of one or more branches of the trigeminal nerve, indicative of neural damage and persisting or recurring for more than 3 months, but of unknown aetiology.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010304 "Unilateral or bilateral facial pain in the distribution(s) of one or more branches of the trigeminal nerve, indicative of neural damage and persisting or recurring for more than 3 months, but of unknown aetiology."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0010304 "PMID:32103673")
 AnnotationAssertion(obo:OHD_0008081 obo:OHD_0010304 "4.1.2.5")
 AnnotationAssertion(dcterms:contributor obo:OHD_0010304 <https://orcid.org/0009-0003-5583-4731>)
@@ -10198,7 +10198,7 @@ SubClassOf(obo:OHD_0010304 ObjectSomeValuesFrom(obo:RO_0002410 obo:OHD_0010251))
 
 # Class: obo:OHD_0010305 (myositis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010305 "A disorder of a muscle caused by inflammation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010305 "A disorder of a muscle caused by inflammation."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010305 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010305 "2025-07-08T18:08:24Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010305 "myositis"@en)
@@ -10207,7 +10207,7 @@ SubClassOf(obo:OHD_0010305 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010306 (inflammatory arthritis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010306 "A disorder of a joint caused by inflammation.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010306 "A disorder of a joint caused by inflammation."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010306 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010306 "2025-07-08T18:10:02Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010306 "inflammatory arthritis"@en)
@@ -10216,7 +10216,7 @@ SubClassOf(obo:OHD_0010306 obo:OGMS_0000045)
 
 # Class: obo:OHD_0010307 (non-systemic inflammatory arthritis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010307 "Arthritis that primarily affects the joints.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010307 "Arthritis that primarily affects the joints."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010307 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010307 "2025-07-08T18:11:28Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010307 "non-systemic inflammatory arthritis"@en)
@@ -10224,7 +10224,7 @@ SubClassOf(obo:OHD_0010307 obo:OHD_0010306)
 
 # Class: obo:OHD_0010308 (systemic inflammatory arthritis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010308 "Arthritis that affects the joints and causes inflammation within the rest of the body.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010308 "Arthritis that affects the joints and causes inflammation within the rest of the body."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010308 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010308 "2025-07-08T18:13:59Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010308 "systemic inflammatory arthritis"@en)
@@ -10232,7 +10232,7 @@ SubClassOf(obo:OHD_0010308 obo:OHD_0010306)
 
 # Class: obo:OHD_0010309 (degenerative joint disease)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010309 "A disease in which the cartilage around the joint is gradually worn away.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0010309 "A disease in which the cartilage around the joint is gradually worn away."@en)
 AnnotationAssertion(dcterms:contributor obo:OHD_0010309 <https://orcid.org/0009-0003-5583-4731>)
 AnnotationAssertion(dcterms:created obo:OHD_0010309 "2025-07-08T18:18:25Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:OHD_0010309 "degenerative joint disease"@en)

--- a/src/ontology/ohd-edit.owl
+++ b/src/ontology/ohd-edit.owl
@@ -1433,7 +1433,7 @@ DataPropertyRange(obo:OHD_0000014 xsd:string)
 
 AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000015 "A data property that relates either:
 1. A finding to the date on which it was recorded
-2. A process to the date on which it occrred")
+2. A process to the date on which it occrred"@en)
 AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000015 "Bill Duncan 5/23/2012:
 There is a problem with occurrence date.  The date on which an event occurred and the date on which it the event was recorded do not always match up.  This will eventually need to be fixed.")
 AnnotationAssertion(rdfs:label obo:OHD_0000015 "occurrence date"@en)
@@ -3220,8 +3220,7 @@ SubClassOf(obo:OHD_0000164 obo:OHD_0000033)
 
 # Class: obo:OHD_0000165 (dental assistant role)
 
-AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000165 "A dental health care provider role that inheres in a person who is a an auxiliary to the dental operator
-.")
+AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000165 "A dental health care provider role that inheres in a person who is a an auxiliary to the dental operator."@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000165 "Mosby. Mosby's Dental Dictionary, 2nd Edition. Mosby, 2008. VitalBook file. p. 55.")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000165 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000165 "dental assistant role"@en)
@@ -3512,7 +3511,6 @@ SubClassOf(obo:OHD_0000198 ObjectSomeValuesFrom(obo:BFO_0000051 ObjectUnionOf(ob
 # Class: obo:OHD_0000199 (prefabricated resin crown restoration procedure)
 
 AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000199 "A resin crown restoration procedure in which the artificial crown has been produced beforehand."@en)
-AnnotationAssertion(obo:IAO_0000117 obo:OHD_0000199 "a resin crown restoration procedure in which the artificial crown has been produced beforehand")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000199 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000199 "prefabricated resin crown restoration procedure"@en)
 SubClassOf(obo:OHD_0000199 obo:OHD_0000154)
@@ -3544,7 +3542,7 @@ SubClassOf(obo:OHD_0000201 ObjectSomeValuesFrom(obo:BFO_0000051 ObjectUnionOf(ob
 AnnotationAssertion(obo:IAO_0000115 obo:OHD_0000202 "An oral evaluation that is performed on new patients; established patients who have had a significant change in health conditions or other unusual circumstances; or established patients who have been absent from active treatment for three or more years. It is a thorough evaluation and recording of the extraoral and intraoral hard and soft tissues. It may require interpretation of information acquired through additional diagnostic procedures. 
 
 This includes an evaluation for oral cancer where indicated, the evaluation and recording of the patients dental and medical history and a general health assessment.  It may include the evaluation and recording of dental caries, missing or unerupted teeth, restorations, existing prostheses, occlusal relationships, periodontal conditions (including periodontal screening and/or charting), hard and soft tissue anomalies, etc.")
-AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000202 "Titus Schleyer 1/1/2014: checked definition, looks okay")
+AnnotationAssertion(obo:IAO_0000116 obo:OHD_0000202 "Titus Schleyer 1/1/2014: checked definition, looks okay"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:OHD_0000202 "ISBN:1935201387#CDT 2011-2012 Current Dental Terminology, Chapter 1")
 AnnotationAssertion(dcterms:contributor obo:OHD_0000202 <https://orcid.org/0000-0001-9625-1899>)
 AnnotationAssertion(rdfs:label obo:OHD_0000202 "comprehensive oral evaluation"@en)


### PR DESCRIPTION
Making fixes for issues which appear in elk test, including missing definitions, duplicate definitions, extra spaces, duplicate labels, and missing parent classes.